### PR TITLE
feat: add pfSense REST API client

### DIFF
--- a/internal/pfsense/client.go
+++ b/internal/pfsense/client.go
@@ -1,9 +1,21 @@
 package pfsense
 
 import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	pathpkg "path"
+	"strings"
 	"time"
 )
+
+const apiPathPrefix = "/api/v2"
 
 // Config contains connection settings for pfSense-pkg-RESTAPI.
 type Config struct {
@@ -24,6 +36,34 @@ type Client struct {
 	httpClient *http.Client
 }
 
+// APIError describes a non-2xx response from pfSense-pkg-RESTAPI.
+type APIError struct {
+	StatusCode int
+	Method     string
+	Path       string
+	Message    string
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	status := fmt.Sprintf("%d", e.StatusCode)
+	if text := http.StatusText(e.StatusCode); text != "" {
+		status = fmt.Sprintf("%s %s", status, text)
+	}
+
+	message := fmt.Sprintf("pfSense REST API %s %s returned %s", e.Method, e.Path, status)
+	if e.Message != "" {
+		message = fmt.Sprintf("%s: %s", message, e.Message)
+	}
+
+	body := strings.TrimSpace(e.Body)
+	if body != "" && !strings.Contains(e.Message, body) {
+		message = fmt.Sprintf("%s (response: %s)", message, truncate(body, 500))
+	}
+
+	return message
+}
+
 // NewClient returns a pfSense REST API client. Endpoint validation happens in
 // provider configuration so tests can construct lightweight clients.
 func NewClient(config Config) *Client {
@@ -32,17 +72,273 @@ func NewClient(config Config) *Client {
 		timeout = 30 * time.Second
 	}
 
+	httpClient := &http.Client{
+		Timeout: timeout,
+	}
+	if config.InsecureTLS {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+		httpClient.Transport = transport
+	}
+
 	return &Client{
-		endpoint: config.Endpoint,
-		apiKey:   config.APIKey,
-		username: config.Username,
-		password: config.Password,
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
+		endpoint:   strings.TrimRight(strings.TrimSpace(config.Endpoint), "/"),
+		apiKey:     config.APIKey,
+		username:   config.Username,
+		password:   config.Password,
+		httpClient: httpClient,
 	}
 }
 
 func (c *Client) Endpoint() string {
 	return c.endpoint
+}
+
+func (c *Client) Get(ctx context.Context, path string, out any) error {
+	return c.Do(ctx, http.MethodGet, path, nil, out)
+}
+
+func (c *Client) Post(ctx context.Context, path string, in any, out any) error {
+	return c.Do(ctx, http.MethodPost, path, in, out)
+}
+
+func (c *Client) Patch(ctx context.Context, path string, in any, out any) error {
+	return c.Do(ctx, http.MethodPatch, path, in, out)
+}
+
+func (c *Client) Put(ctx context.Context, path string, in any, out any) error {
+	return c.Do(ctx, http.MethodPut, path, in, out)
+}
+
+func (c *Client) Delete(ctx context.Context, path string, out any) error {
+	return c.Do(ctx, http.MethodDelete, path, nil, out)
+}
+
+// Do sends a JSON request to pfSense-pkg-RESTAPI and decodes a JSON response.
+func (c *Client) Do(ctx context.Context, method string, path string, in any, out any) error {
+	if ctx == nil {
+		return errors.New("pfSense REST API request requires a non-nil context")
+	}
+
+	requestURL, displayPath, err := c.requestURL(path)
+	if err != nil {
+		return err
+	}
+
+	var body io.Reader
+	if in != nil {
+		encoded, err := json.Marshal(in)
+		if err != nil {
+			return fmt.Errorf("encode %s %s request: %w", method, displayPath, err)
+		}
+		body = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, body)
+	if err != nil {
+		return fmt.Errorf("create %s %s request: %w", method, displayPath, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if in != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	c.setAuth(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s request failed: %w", method, displayPath, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode > 299 {
+		return newAPIError(resp, method, displayPath)
+	}
+
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read %s %s response: %w", method, displayPath, err)
+	}
+	if len(bytes.TrimSpace(responseBody)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(responseBody, out); err != nil {
+		return fmt.Errorf("decode %s %s response: %w", method, displayPath, err)
+	}
+
+	return nil
+}
+
+func (c *Client) setAuth(req *http.Request) {
+	if c.apiKey != "" {
+		req.Header.Set("X-API-Key", c.apiKey)
+		return
+	}
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+}
+
+func (c *Client) requestURL(requestPath string) (string, string, error) {
+	if c.endpoint == "" {
+		return "", "", errors.New("pfSense REST API endpoint is required")
+	}
+
+	baseURL, err := url.Parse(c.endpoint)
+	if err != nil {
+		return "", "", fmt.Errorf("parse pfSense REST API endpoint %q: %w", c.endpoint, err)
+	}
+	if baseURL.Scheme == "" || baseURL.Host == "" {
+		return "", "", fmt.Errorf("pfSense REST API endpoint %q must be an absolute URL", c.endpoint)
+	}
+
+	relativeURL, err := url.Parse(requestPath)
+	if err != nil {
+		return "", "", fmt.Errorf("parse pfSense REST API path %q: %w", requestPath, err)
+	}
+	if relativeURL.IsAbs() || relativeURL.Host != "" {
+		return "", "", fmt.Errorf("pfSense REST API path %q must be relative", requestPath)
+	}
+
+	joinedPath := joinAPIPath(baseURL.Path, relativeURL.Path)
+	baseURL.Path = joinedPath
+	baseURL.RawPath = ""
+	baseURL.RawQuery = relativeURL.RawQuery
+	baseURL.Fragment = ""
+
+	displayPath := joinedPath
+	if relativeURL.RawQuery != "" {
+		displayPath = displayPath + "?" + relativeURL.RawQuery
+	}
+
+	return baseURL.String(), displayPath, nil
+}
+
+func joinAPIPath(basePath string, requestPath string) string {
+	basePath = strings.TrimRight(basePath, "/")
+	requestPath = "/" + strings.TrimLeft(requestPath, "/")
+	if requestPath == "/" {
+		requestPath = ""
+	}
+
+	var joined string
+	switch {
+	case strings.HasPrefix(requestPath, apiPathPrefix+"/") || requestPath == apiPathPrefix:
+		if strings.HasSuffix(basePath, apiPathPrefix) {
+			requestPath = strings.TrimPrefix(requestPath, apiPathPrefix)
+		}
+		joined = pathpkg.Join(basePath, requestPath)
+	case strings.HasSuffix(basePath, apiPathPrefix):
+		joined = pathpkg.Join(basePath, requestPath)
+	default:
+		joined = pathpkg.Join(basePath, apiPathPrefix, requestPath)
+	}
+
+	if joined == "." || joined == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(joined, "/") {
+		return "/" + joined
+	}
+	return joined
+}
+
+func newAPIError(resp *http.Response, method string, path string) error {
+	bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	body := strings.TrimSpace(string(bodyBytes))
+
+	message := statusGuidance(resp.StatusCode)
+	if detail := errorDetail(body); detail != "" {
+		message = message + ": " + detail
+	}
+	if readErr != nil {
+		message = message + fmt.Sprintf(": failed to read error response body: %v", readErr)
+	}
+
+	return &APIError{
+		StatusCode: resp.StatusCode,
+		Method:     method,
+		Path:       path,
+		Message:    message,
+		Body:       body,
+	}
+}
+
+func statusGuidance(statusCode int) string {
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return "authentication failed; check the configured API key or username/password"
+	case http.StatusForbidden:
+		return "authorization failed; check REST API privileges for the configured user or key"
+	case http.StatusNotFound:
+		return "endpoint or object was not found"
+	case http.StatusConflict:
+		return "request conflicted with existing pfSense configuration"
+	case http.StatusUnprocessableEntity:
+		return "request validation failed"
+	default:
+		if statusCode >= 500 {
+			return "pfSense REST API server error; retry or inspect pfSense REST API logs"
+		}
+		return "pfSense REST API request failed"
+	}
+}
+
+func errorDetail(body string) string {
+	if body == "" {
+		return ""
+	}
+
+	var payload any
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		return truncate(body, 500)
+	}
+
+	if detail := detailFromValue(payload); detail != "" {
+		return truncate(detail, 500)
+	}
+
+	return truncate(body, 500)
+}
+
+func detailFromValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case map[string]any:
+		for _, key := range []string{"message", "error", "detail", "details", "description", "errors"} {
+			if field, ok := typed[key]; ok {
+				if detail := detailFromValue(field); detail != "" {
+					return detail
+				}
+			}
+		}
+	case []any:
+		details := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if detail := detailFromValue(item); detail != "" {
+				details = append(details, detail)
+			}
+		}
+		return strings.Join(details, "; ")
+	}
+
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func truncate(value string, maxLength int) string {
+	if len(value) <= maxLength {
+		return value
+	}
+	return value[:maxLength] + "..."
 }

--- a/internal/pfsense/client.go
+++ b/internal/pfsense/client.go
@@ -309,18 +309,14 @@ func parseEnvelope(body []byte) (responseEnvelope, bool) {
 		return responseEnvelope{}, false
 	}
 
-	envelopeMarkers := []string{"code", "status", "response_id"}
-	hasEnvelopeMarker := false
-	for _, key := range envelopeMarkers {
-		if _, ok := raw[key]; ok {
-			hasEnvelopeMarker = true
-			break
-		}
-	}
-	if !hasEnvelopeMarker {
+	if _, ok := raw["code"]; !ok {
 		return responseEnvelope{}, false
 	}
-
+	if _, ok := raw["data"]; !ok {
+		if _, ok := raw["message"]; !ok {
+			return responseEnvelope{}, false
+		}
+	}
 	var envelope responseEnvelope
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		return responseEnvelope{}, false

--- a/internal/pfsense/client.go
+++ b/internal/pfsense/client.go
@@ -39,8 +39,10 @@ type Client struct {
 // APIError describes a non-2xx response from pfSense-pkg-RESTAPI.
 type APIError struct {
 	StatusCode int
+	Code       int
 	Method     string
 	Path       string
+	ResponseID string
 	Message    string
 	Body       string
 }
@@ -54,6 +56,9 @@ func (e *APIError) Error() string {
 	message := fmt.Sprintf("pfSense REST API %s %s returned %s", e.Method, e.Path, status)
 	if e.Message != "" {
 		message = fmt.Sprintf("%s: %s", message, e.Message)
+	}
+	if e.ResponseID != "" {
+		message = fmt.Sprintf("%s (response_id: %s)", message, e.ResponseID)
 	}
 
 	body := strings.TrimSpace(e.Body)
@@ -156,16 +161,31 @@ func (c *Client) Do(ctx context.Context, method string, path string, in any, out
 		return newAPIError(resp, method, displayPath)
 	}
 
-	if out == nil {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil
-	}
-
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("read %s %s response: %w", method, displayPath, err)
 	}
 	if len(bytes.TrimSpace(responseBody)) == 0 {
+		return nil
+	}
+
+	if envelope, ok := parseEnvelope(responseBody); ok {
+		if envelope.Code >= 400 {
+			return envelopeAPIError(resp.StatusCode, method, displayPath, responseBody, envelope)
+		}
+		if out == nil {
+			return nil
+		}
+		if len(envelope.Data) == 0 || string(envelope.Data) == "null" {
+			return nil
+		}
+		if err := json.Unmarshal(envelope.Data, out); err != nil {
+			return fmt.Errorf("decode %s %s response data: %w", method, displayPath, err)
+		}
+		return nil
+	}
+
+	if out == nil {
 		return nil
 	}
 	if err := json.Unmarshal(responseBody, out); err != nil {
@@ -254,6 +274,10 @@ func newAPIError(resp *http.Response, method string, path string) error {
 	body := strings.TrimSpace(string(bodyBytes))
 
 	message := statusGuidance(resp.StatusCode)
+	envelope, hasEnvelope := parseEnvelope(bodyBytes)
+	if hasEnvelope && envelope.Code >= 400 {
+		return envelopeAPIError(resp.StatusCode, method, path, bodyBytes, envelope)
+	}
 	if detail := errorDetail(body); detail != "" {
 		message = message + ": " + detail
 	}
@@ -267,6 +291,60 @@ func newAPIError(resp *http.Response, method string, path string) error {
 		Path:       path,
 		Message:    message,
 		Body:       body,
+	}
+}
+
+type responseEnvelope struct {
+	Code       int             `json:"code"`
+	Status     string          `json:"status"`
+	ResponseID string          `json:"response_id"`
+	Message    json.RawMessage `json:"message"`
+	Data       json.RawMessage `json:"data"`
+	Links      json.RawMessage `json:"_links"`
+}
+
+func parseEnvelope(body []byte) (responseEnvelope, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return responseEnvelope{}, false
+	}
+
+	envelopeMarkers := []string{"code", "status", "response_id"}
+	hasEnvelopeMarker := false
+	for _, key := range envelopeMarkers {
+		if _, ok := raw[key]; ok {
+			hasEnvelopeMarker = true
+			break
+		}
+	}
+	if !hasEnvelopeMarker {
+		return responseEnvelope{}, false
+	}
+
+	var envelope responseEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return responseEnvelope{}, false
+	}
+	return envelope, true
+}
+
+func envelopeAPIError(statusCode int, method string, path string, body []byte, envelope responseEnvelope) error {
+	message := statusGuidance(statusCode)
+	if statusCode >= http.StatusOK && statusCode <= 299 {
+		message = "pfSense REST API returned an error envelope"
+	}
+	if detail := detailFromRawMessage(envelope.Message); detail != "" {
+		message = message + ": " + detail
+	}
+
+	return &APIError{
+		StatusCode: statusCode,
+		Code:       envelope.Code,
+		Method:     method,
+		Path:       path,
+		ResponseID: envelope.ResponseID,
+		Message:    message,
+		Body:       strings.TrimSpace(string(body)),
 	}
 }
 
@@ -305,6 +383,18 @@ func errorDetail(body string) string {
 	}
 
 	return truncate(body, 500)
+}
+
+func detailFromRawMessage(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return truncate(string(raw), 500)
+	}
+	return truncate(detailFromValue(value), 500)
 }
 
 func detailFromValue(value any) string {

--- a/internal/pfsense/client.go
+++ b/internal/pfsense/client.go
@@ -62,7 +62,7 @@ func (e *APIError) Error() string {
 	}
 
 	body := strings.TrimSpace(e.Body)
-	if body != "" && !strings.Contains(e.Message, body) {
+	if body != "" && !json.Valid([]byte(body)) && !strings.Contains(e.Message, body) {
 		message = fmt.Sprintf("%s (response: %s)", message, truncate(body, 500))
 	}
 
@@ -329,16 +329,21 @@ func parseEnvelope(body []byte) (responseEnvelope, bool) {
 }
 
 func envelopeAPIError(statusCode int, method string, path string, body []byte, envelope responseEnvelope) error {
-	message := statusGuidance(statusCode)
+	effectiveStatusCode := statusCode
+	if envelope.Code >= 400 {
+		effectiveStatusCode = envelope.Code
+	}
+
+	message := statusGuidance(effectiveStatusCode)
 	if statusCode >= http.StatusOK && statusCode <= 299 {
-		message = "pfSense REST API returned an error envelope"
+		message = message + "; pfSense REST API returned an error envelope"
 	}
 	if detail := detailFromRawMessage(envelope.Message); detail != "" {
 		message = message + ": " + detail
 	}
 
 	return &APIError{
-		StatusCode: statusCode,
+		StatusCode: effectiveStatusCode,
 		Code:       envelope.Code,
 		Method:     method,
 		Path:       path,

--- a/internal/pfsense/client_test.go
+++ b/internal/pfsense/client_test.go
@@ -283,6 +283,28 @@ func TestEnvelopeResponseDecodesData(t *testing.T) {
 	}
 }
 
+func TestNonEnvelopeResponseWithStatusFieldDecodesNormally(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"enabled","name":"haproxy"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+	var response struct {
+		Status string `json:"status"`
+		Name   string `json:"name"`
+	}
+	if err := client.Get(context.Background(), "/services/haproxy/status", &response); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if response.Status != "enabled" || response.Name != "haproxy" {
+		t.Fatalf("response = %#v", response)
+	}
+}
+
 func TestEnvelopeErrorWithHTTPSuccessIsActionable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pfsense/client_test.go
+++ b/internal/pfsense/client_test.go
@@ -1,0 +1,352 @@
+package pfsense
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetUsesAPIKeyAuth(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if r.URL.RequestURI() != "/api/v2/system/status?scope=wan" {
+			t.Fatalf("request uri = %s", r.URL.RequestURI())
+		}
+		if got := r.Header.Get("X-API-Key"); got != "test-key" {
+			t.Fatalf("X-API-Key = %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Fatalf("Accept = %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{
+		Endpoint: server.URL,
+		APIKey:   "test-key",
+		Username: "ignored",
+		Password: "ignored",
+	})
+
+	var response struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.Get(context.Background(), "/system/status?scope=wan", &response); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if !response.OK {
+		t.Fatalf("response not decoded")
+	}
+}
+
+func TestPostUsesBasicAuthFallback(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if got := r.Header.Get("X-API-Key"); got != "" {
+			t.Fatalf("X-API-Key = %q", got)
+		}
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "api-user" || password != "api-pass" {
+			t.Fatalf("basic auth = %q/%q present=%t", username, password, ok)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q", got)
+		}
+
+		var request struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if request.Name != "backend-a" {
+			t.Fatalf("request name = %q", request.Name)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"created"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{
+		Endpoint: server.URL + "/",
+		Username: "api-user",
+		Password: "api-pass",
+	})
+
+	var response struct {
+		ID string `json:"id"`
+	}
+	if err := client.Post(context.Background(), "haproxy/backends", map[string]string{"name": "backend-a"}, &response); err != nil {
+		t.Fatalf("Post returned error: %v", err)
+	}
+	if response.ID != "created" {
+		t.Fatalf("response id = %q", response.ID)
+	}
+}
+
+func TestHTTPMethodHelpers(t *testing.T) {
+	t.Parallel()
+
+	type call struct {
+		method string
+		run    func(context.Context, *Client, any) error
+		body   bool
+	}
+
+	calls := []call{
+		{
+			method: http.MethodGet,
+			run: func(ctx context.Context, client *Client, out any) error {
+				return client.Get(ctx, "/haproxy/test", out)
+			},
+		},
+		{
+			method: http.MethodPost,
+			run: func(ctx context.Context, client *Client, out any) error {
+				return client.Post(ctx, "/haproxy/test", map[string]string{"method": http.MethodPost}, out)
+			},
+			body: true,
+		},
+		{
+			method: http.MethodPatch,
+			run: func(ctx context.Context, client *Client, out any) error {
+				return client.Patch(ctx, "/haproxy/test", map[string]string{"method": http.MethodPatch}, out)
+			},
+			body: true,
+		},
+		{
+			method: http.MethodPut,
+			run: func(ctx context.Context, client *Client, out any) error {
+				return client.Put(ctx, "/haproxy/test", map[string]string{"method": http.MethodPut}, out)
+			},
+			body: true,
+		},
+		{
+			method: http.MethodDelete,
+			run: func(ctx context.Context, client *Client, out any) error {
+				return client.Delete(ctx, "/haproxy/test", out)
+			},
+		},
+	}
+
+	for _, tc := range calls {
+		tc := tc
+		t.Run(tc.method, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tc.method {
+					t.Fatalf("method = %s", r.Method)
+				}
+				if r.URL.Path != "/api/v2/haproxy/test" {
+					t.Fatalf("path = %s", r.URL.Path)
+				}
+
+				if tc.body {
+					var request map[string]string
+					if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+						t.Fatalf("decode request body: %v", err)
+					}
+					if request["method"] != tc.method {
+						t.Fatalf("request method field = %q", request["method"])
+					}
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+			var response struct {
+				OK bool `json:"ok"`
+			}
+			if err := tc.run(context.Background(), client, &response); err != nil {
+				t.Fatalf("%s helper returned error: %v", tc.method, err)
+			}
+			if !response.OK {
+				t.Fatalf("response not decoded")
+			}
+		})
+	}
+}
+
+func TestAPIErrorResponsesAreActionable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status   int
+		contains []string
+	}{
+		{status: http.StatusUnauthorized, contains: []string{"401 Unauthorized", "authentication failed", "check the configured API key"}},
+		{status: http.StatusForbidden, contains: []string{"403 Forbidden", "authorization failed", "REST API privileges"}},
+		{status: http.StatusNotFound, contains: []string{"404 Not Found", "endpoint or object was not found"}},
+		{status: http.StatusConflict, contains: []string{"409 Conflict", "conflicted with existing pfSense configuration"}},
+		{status: http.StatusUnprocessableEntity, contains: []string{"422 Unprocessable Entity", "request validation failed"}},
+		{status: http.StatusInternalServerError, contains: []string{"500 Internal Server Error", "server error", "pfSense REST API logs"}},
+		{status: http.StatusBadGateway, contains: []string{"502 Bad Gateway", "server error", "pfSense REST API logs"}},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"message":"pfSense rejected the request"}`))
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+			err := client.Get(context.Background(), "/haproxy/test", nil)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected APIError, got %T", err)
+			}
+			if apiErr.StatusCode != tc.status {
+				t.Fatalf("status code = %d", apiErr.StatusCode)
+			}
+			if apiErr.Method != http.MethodGet {
+				t.Fatalf("method = %s", apiErr.Method)
+			}
+			if apiErr.Path != "/api/v2/haproxy/test" {
+				t.Fatalf("path = %s", apiErr.Path)
+			}
+			if !strings.Contains(apiErr.Body, "pfSense rejected the request") {
+				t.Fatalf("body = %q", apiErr.Body)
+			}
+
+			errorMessage := err.Error()
+			for _, want := range tc.contains {
+				if !strings.Contains(errorMessage, want) {
+					t.Fatalf("error %q does not contain %q", errorMessage, want)
+				}
+			}
+			if !strings.Contains(errorMessage, "pfSense rejected the request") {
+				t.Fatalf("error %q does not contain response message", errorMessage)
+			}
+		})
+	}
+}
+
+func TestAPIErrorIncludesPlainTextBody(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("maintenance window active"))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+	err := client.Get(context.Background(), "/haproxy/test", nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "maintenance window active") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+func TestEndpointPathJoining(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		endpointPath string
+		requestPath  string
+		wantPath     string
+	}{
+		{
+			name:        "root endpoint",
+			requestPath: "system/status",
+			wantPath:    "/api/v2/system/status",
+		},
+		{
+			name:         "endpoint with prefix",
+			endpointPath: "/rest",
+			requestPath:  "/system/status",
+			wantPath:     "/rest/api/v2/system/status",
+		},
+		{
+			name:         "endpoint already includes api prefix",
+			endpointPath: "/api/v2",
+			requestPath:  "/system/status",
+			wantPath:     "/api/v2/system/status",
+		},
+		{
+			name:        "request already includes api prefix",
+			requestPath: "/api/v2/system/status",
+			wantPath:    "/api/v2/system/status",
+		},
+		{
+			name:         "endpoint and request include api prefix",
+			endpointPath: "/api/v2",
+			requestPath:  "/api/v2/system/status",
+			wantPath:     "/api/v2/system/status",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tc.wantPath {
+					t.Fatalf("path = %s, want %s", r.URL.Path, tc.wantPath)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewClient(Config{
+				Endpoint: server.URL + tc.endpointPath,
+				APIKey:   "test-key",
+			})
+			if err := client.Get(context.Background(), tc.requestPath, nil); err != nil {
+				t.Fatalf("Get returned error: %v", err)
+			}
+		})
+	}
+}
+
+func TestTimeoutFromConfig(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Config{
+		Endpoint: "https://pfsense.example.com",
+		APIKey:   "test-key",
+		Timeout:  5 * time.Second,
+	})
+
+	if client.httpClient.Timeout != 5*time.Second {
+		t.Fatalf("timeout = %s", client.httpClient.Timeout)
+	}
+}

--- a/internal/pfsense/client_test.go
+++ b/internal/pfsense/client_test.go
@@ -255,6 +255,102 @@ func TestAPIErrorResponsesAreActionable(t *testing.T) {
 	}
 }
 
+func TestEnvelopeResponseDecodesData(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"code": 200,
+			"status": "ok",
+			"response_id": "resp-success",
+			"message": "ok",
+			"data": {"enabled": true, "name": "haproxy"}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+	var response struct {
+		Enabled bool   `json:"enabled"`
+		Name    string `json:"name"`
+	}
+	if err := client.Get(context.Background(), "/services/haproxy/settings", &response); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if !response.Enabled || response.Name != "haproxy" {
+		t.Fatalf("response = %#v", response)
+	}
+}
+
+func TestEnvelopeErrorWithHTTPSuccessIsActionable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"code": 422,
+			"status": "error",
+			"response_id": "resp-validation",
+			"message": "invalid backend name",
+			"data": {"field": "name"}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+	err := client.Post(context.Background(), "/services/haproxy/backend", map[string]string{"name": ""}, nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusOK {
+		t.Fatalf("status code = %d", apiErr.StatusCode)
+	}
+	if apiErr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("envelope code = %d", apiErr.Code)
+	}
+	if apiErr.ResponseID != "resp-validation" {
+		t.Fatalf("response id = %q", apiErr.ResponseID)
+	}
+	for _, want := range []string{"error envelope", "invalid backend name", "response_id: resp-validation"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
+func TestEnvelopeErrorWithHTTPFailureIncludesResponseID(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{
+			"code": 403,
+			"status": "error",
+			"response_id": "resp-forbidden",
+			"message": {"error": "missing HAProxy privilege"}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+	err := client.Get(context.Background(), "/services/haproxy/frontends", nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	for _, want := range []string{"403 Forbidden", "missing HAProxy privilege", "response_id: resp-forbidden"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
 func TestAPIErrorIncludesPlainTextBody(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pfsense/client_test.go
+++ b/internal/pfsense/client_test.go
@@ -308,7 +308,7 @@ func TestEnvelopeErrorWithHTTPSuccessIsActionable(t *testing.T) {
 	if !errors.As(err, &apiErr) {
 		t.Fatalf("expected APIError, got %T", err)
 	}
-	if apiErr.StatusCode != http.StatusOK {
+	if apiErr.StatusCode != http.StatusUnprocessableEntity {
 		t.Fatalf("status code = %d", apiErr.StatusCode)
 	}
 	if apiErr.Code != http.StatusUnprocessableEntity {
@@ -317,10 +317,13 @@ func TestEnvelopeErrorWithHTTPSuccessIsActionable(t *testing.T) {
 	if apiErr.ResponseID != "resp-validation" {
 		t.Fatalf("response id = %q", apiErr.ResponseID)
 	}
-	for _, want := range []string{"error envelope", "invalid backend name", "response_id: resp-validation"} {
+	for _, want := range []string{"422 Unprocessable Entity", "error envelope", "invalid backend name", "response_id: resp-validation"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q does not contain %q", err.Error(), want)
 		}
+	}
+	if strings.Contains(err.Error(), `"field": "name"`) || strings.Contains(err.Error(), `"data"`) {
+		t.Fatalf("error leaks full structured body: %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add context-aware pfSense REST API JSON client helpers for GET/POST/PATCH/PUT/DELETE.
- Add API key authentication with Basic Auth fallback.
- Add typed APIError diagnostics for HTTP and pfREST envelope failures, including response_id.
- Add httptest coverage for auth, methods, path joining, error classes, envelopes, and timeout config.

## Verification
- `make lint`
- `make test`

## Cruise Roles
- Implementer: fresh worker agent, commit `fe8df2b`
- Tester: local `make lint` / `make test`, httptest suite
- Consultant: fresh research agent for pfREST auth/envelope semantics
- Reviewer: fresh adversarial reviewer before PR ready

Closes #2
