### PR TITLE
feat(schema): add HAProxy schema capture workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ dist/
 coverage.out
 *.test
 
+# Python helper caches
+__pycache__/
+*.py[cod]
+
 # Terraform
 .terraform/
 *.tfstate
@@ -22,6 +26,13 @@ pfsense-test-config.yaml
 *.p12
 config.xml
 config-*.xml
+
+# Raw schema captures
+docs/schema/raw/
+docs/fixtures/raw/
+docs/schema/**/*.raw.json
+docs/fixtures/**/*.raw.json
+*.unredacted.json
 
 # Editor/OS
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,11 @@ make testacc
 ```
 
 Do not commit credentials, pfSense backups, certificates, or VPN material.
+
+## Schema and fixture artifacts
+
+Use `scripts/capture_haproxy_schema.py` for UAT schema capture. Commit only
+reviewed, redacted JSON outputs and documentation under `docs/schema/`.
+
+Never commit raw schema captures, live HAProxy configuration dumps, API keys,
+passwords, JWTs, certificates, private keys, or pfSense `config.xml` backups.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Changes should be delivered through focused issues and pull requests.
 ```bash
 make lint
 make test
+python3 -m unittest scripts/capture_haproxy_schema_test.py
 ```
 
 Acceptance tests require a real pfSense instance with pfSense-pkg-RESTAPI and the HAProxy package installed:

--- a/README.md
+++ b/README.md
@@ -86,3 +86,16 @@ resource "pfsense_haproxy_backend_server" "addressvalidator_01" {
 ```
 
 The exact schemas will be finalized from pfSense REST API endpoint responses during Milestone 1.
+
+## Schema inventory
+
+HAProxy endpoint inventory and provisional resource schema decisions are tracked
+under `docs/schema/`. Live schema captures must be generated with:
+
+```bash
+python3 scripts/capture_haproxy_schema.py --schema both --output-dir docs/schema
+```
+
+Only redacted `haproxy-*.redacted.json` artifacts may be committed. Raw captures,
+credentials, certificates, API tokens, and pfSense config backups must stay out
+of Git.

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -1,0 +1,72 @@
+# HAProxy Schema Capture Workflow
+
+This directory is for redacted pfSense-pkg-RESTAPI schema metadata used to design
+the Terraform provider resources. It must never contain live credentials,
+certificates, private keys, API tokens, VPN material, pfSense `config.xml`
+backups, or unredacted HAProxy configuration dumps.
+
+## Sources
+
+- pfREST guide: https://pfrest.org/SWAGGER_AND_OPENAPI/
+- Native schema guide: https://pfrest.org/NATIVE_SCHEMA/
+- Public OpenAPI reference: https://pfrest.org/api-docs/
+
+The public OpenAPI reference is useful for initial endpoint inventory. UAT remains
+the source of truth for this deployment because installed pfSense, package, and
+pfSense-pkg-RESTAPI versions can differ from the public reference.
+
+## Capture
+
+Use only approved UAT targets. The script reads schema endpoints only:
+
+```bash
+export PFSENSE_ENDPOINT=https://pfsense.example.com
+export PFSENSE_API_KEY=...
+export PFSENSE_INSECURE_TLS=true
+
+python3 scripts/capture_haproxy_schema.py --schema both --output-dir docs/schema
+```
+
+Username/password fallback is supported when API keys are unavailable:
+
+```bash
+export PFSENSE_USERNAME=...
+export PFSENSE_PASSWORD=...
+```
+
+The script fetches:
+
+- `/api/v2/schema/openapi`
+- `/api/v2/schema/native`
+
+It filters HAProxy paths containing `/api/v2/services/haproxy`, keeps referenced
+HAProxy schemas/models, redacts sensitive scalar values, and writes:
+
+- `docs/schema/haproxy-openapi.redacted.json`
+- `docs/schema/haproxy-native.redacted.json`
+
+Raw captures are intentionally ignored by Git and must not be committed.
+
+## Pre-Commit Review
+
+Before committing any generated JSON:
+
+```bash
+python3 scripts/capture_haproxy_schema.py --dry-run
+jq empty docs/schema/haproxy-*.redacted.json
+rg -n -- '-----BEGIN|PRIVATE KEY|<pfsense|Authorization:|Bearer [A-Za-z0-9]|Basic [A-Za-z0-9]|PFSENSE_(API_KEY|PASSWORD)' docs/schema
+```
+
+If the final `rg` command returns anything other than intentional policy text in
+Markdown docs, stop and redact or remove the artifact before committing.
+
+## Current UAT Status
+
+As of 2026-04-28, live UAT schema capture is blocked from this environment:
+
+- `https://192.168.51.254/api/v2/schema/openapi` timed out.
+- `https://192.168.31.254/api/v2/schema/openapi` timed out.
+
+No live UAT fixture is committed for this issue. The endpoint inventory and
+resource decisions in this directory are based on primary pfREST documentation
+and are marked pending UAT confirmation.

--- a/docs/schema/haproxy-endpoint-inventory.md
+++ b/docs/schema/haproxy-endpoint-inventory.md
@@ -1,0 +1,60 @@
+# HAProxy Endpoint Inventory
+
+Status: pending UAT confirmation. The live UAT schema probes for
+`https://192.168.51.254/api/v2/schema/openapi` and
+`https://192.168.31.254/api/v2/schema/openapi` timed out from this environment
+on 2026-04-28, so this inventory uses the primary pfREST public OpenAPI reference
+instead of a live fixture.
+
+Primary references:
+
+- https://pfrest.org/SWAGGER_AND_OPENAPI/
+- https://pfrest.org/NATIVE_SCHEMA/
+- https://pfrest.org/api-docs/
+
+The public OpenAPI reference reports `pfSense REST API Documentation` version
+`v2.7.6`. Every HAProxy endpoint below lists `pfSense-pkg-haproxy` as its
+required package and supports `BasicAuth`, `JWTAuth`, and `KeyAuth` in the
+published documentation.
+
+| Path | Methods | Type | Model | Required package | UAT |
+|------|---------|------|-------|------------------|-----|
+| `/api/v2/services/haproxy/apply` | GET, POST | Singular | HAProxyApply | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backend/acl` | GET, POST, PATCH, DELETE | Singular | HAProxyBackendACL | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backend/acls` | GET, DELETE | Plural | HAProxyBackendACL | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backend/action` | GET, POST, PATCH, DELETE | Singular | HAProxyBackendAction | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backend/actions` | GET, DELETE | Plural | HAProxyBackendAction | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backend` | GET, POST, PATCH, DELETE | Singular | HAProxyBackend | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backend/error_file` | GET, POST, PATCH, DELETE | Singular | HAProxyBackendErrorFile | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backend/errorfiles` | GET, DELETE | Plural | HAProxyBackendErrorFile | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backend/server` | GET, POST, PATCH, DELETE | Singular | HAProxyBackendServer | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backend/servers` | GET, DELETE | Plural | HAProxyBackendServer | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backends` | GET, PUT, DELETE | Plural | HAProxyBackend | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/file` | GET, POST, PATCH, DELETE | Singular | HAProxyFile | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/files` | GET, PUT, DELETE | Plural | HAProxyFile | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/acl` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendACL | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/acls` | GET, DELETE | Plural | HAProxyFrontendACL | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/action` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendAction | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/actions` | GET, DELETE | Plural | HAProxyFrontendAction | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/address` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendAddress | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/addresses` | GET, DELETE | Plural | HAProxyFrontendAddress | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/certificate` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendCertificate | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/certificates` | GET, DELETE | Plural | HAProxyFrontendCertificate | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontend | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/error_file` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendErrorFile | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/error_files` | GET, DELETE | Plural | HAProxyFrontendErrorFile | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontends` | GET, PUT, DELETE | Plural | HAProxyFrontend | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/settings/dns_resolver` | GET, POST, PATCH, DELETE | Singular | HAProxyDNSResolver | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/settings/dns_resolvers` | GET, DELETE | Plural | HAProxyDNSResolver | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/settings/email_mailer` | GET, POST, PATCH, DELETE | Singular | HAProxyEmailMailer | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/settings/email_mailers` | GET, DELETE | Plural | HAProxyEmailMailer | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/settings` | GET, PATCH | Singular | HAProxySettings | pfSense-pkg-haproxy | Pending |
+
+## Notes For UAT Confirmation
+
+- Confirm whether UAT exposes the same path list and method set.
+- Confirm package name and version metadata from `/api/v2/schema/native`.
+- Confirm singular object ID behavior and child `parent_id` behavior from live
+  schema metadata before implementing import or drift detection.
+- Do not use plural `PUT` replacement or plural `DELETE` endpoints from
+  Terraform resources until an import/migration plan exists.

--- a/docs/schema/resource-schema-decisions.md
+++ b/docs/schema/resource-schema-decisions.md
@@ -1,0 +1,65 @@
+# Resource Schema Decisions
+
+Status: provisional from primary pfREST documentation. UAT schema capture is
+pending because both live UAT OpenAPI probes timed out from this environment on
+2026-04-28.
+
+Primary references:
+
+- https://pfrest.org/SWAGGER_AND_OPENAPI/
+- https://pfrest.org/api-docs/
+
+## Cross-Cutting Decisions
+
+- Use `KeyAuth`/`PFSENSE_API_KEY` for automation. Basic auth remains a fallback
+  for capture and acceptance work.
+- Treat singular object operations as ID-addressed API calls. Published OpenAPI
+  documents an `id` query parameter for top-level singular reads, patches, and
+  deletes.
+- Treat child operations as parent-addressed API calls. Published OpenAPI
+  documents `parent_id` plus child `id` for child reads, patches, and deletes.
+- Model Terraform resource IDs to preserve both parent and child API IDs for
+  child resources. The exact serialized ID format remains pending UAT response
+  confirmation.
+- Do not use plural `PUT` replace-all endpoints or plural query `DELETE`
+  endpoints for normal single-resource lifecycle operations.
+- HAProxy write endpoints do not apply pending service changes immediately in
+  the public OpenAPI metadata. Use an explicit apply workflow instead of hidden
+  automatic reloads.
+- Mark actual secret-bearing attributes as sensitive when implemented. Public
+  schema names include `stats_password`, `HAProxyFile.content`, certificate
+  references, and custom/advanced HAProxy text fields that may carry private
+  material.
+
+## Resource Mapping
+
+| Terraform resource | API model | Primary endpoints | Documented create/update shape | Decision |
+|--------------------|-----------|-------------------|--------------------------------|----------|
+| `pfsense_haproxy_settings` | HAProxySettings | `GET/PATCH /api/v2/services/haproxy/settings` | Settings patch body is partial; no create/delete. | Singleton resource. Import by fixed ID such as `settings` after UAT confirms response shape. |
+| `pfsense_haproxy_backend` | HAProxyBackend | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend`; `GET /backends` | Create requires `name`, `agent_port`, and `persist_cookie_name` in public OpenAPI. Patch requires `id`. | Durable top-level resource. Keep embedded collections read-only or ignored when managed by child resources. |
+| `pfsense_haproxy_backend_server` | HAProxyBackendServer | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/server` | Create requires `parent_id`, `name`, `address`, `port`. Patch requires `parent_id`, `id`. | Child resource under backend. Terraform ID must retain backend API ID and server API ID. |
+| `pfsense_haproxy_backend_acl` | HAProxyBackendACL | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/acl` | Create requires `parent_id`, `name`, `expression`, `value`. Patch requires `parent_id`, `id`. | Child resource under backend. |
+| `pfsense_haproxy_backend_action` | HAProxyBackendAction | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/action` | Create requires `parent_id` plus action-specific fields in the public schema. | Child resource under backend. Conditional fields need UAT examples before strict Terraform validation. |
+| `pfsense_haproxy_backend_error_file` | HAProxyBackendErrorFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/error_file` | Create requires `parent_id`, `errorcode`, `errorfile`. | Child resource under backend. Consider later if required for managed routes. |
+| `pfsense_haproxy_frontend` | HAProxyFrontend | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend`; `GET /frontends` | Create requires `name` and `type`. Patch requires `id`. | Durable top-level resource. Keep addresses, ACLs, actions, certificates, and error files as child resources where possible. |
+| `pfsense_haproxy_frontend_address` | HAProxyFrontendAddress | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/address` | Create requires `parent_id`, `extaddr`, `extaddr_custom`. Patch requires `parent_id`, `id`. | Child resource under frontend. |
+| `pfsense_haproxy_frontend_acl` | HAProxyFrontendACL | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/acl` | Create requires `parent_id`, `name`, `expression`, `value`. Patch requires `parent_id`, `id`. | Child resource under frontend. |
+| `pfsense_haproxy_frontend_action` | HAProxyFrontendAction | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/action` | Create requires `parent_id` plus action-specific fields in the public schema. | Child resource under frontend. Conditional fields need UAT examples before strict Terraform validation. |
+| `pfsense_haproxy_frontend_certificate` | HAProxyFrontendCertificate | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/certificate` | Create requires `parent_id`; schema exposes `ssl_certificate`. | Child resource under frontend. Treat certificate identifiers as sensitive-adjacent and never capture certificate bodies. |
+| `pfsense_haproxy_frontend_error_file` | HAProxyFrontendErrorFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/error_file` | Create requires `parent_id`, `errorcode`, `errorfile`. | Child resource under frontend. Consider later if required for managed routes. |
+| `pfsense_haproxy_file` | HAProxyFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/file`; `GET /files` | Create requires `name`, `content`. Patch requires `id`. | Defer until routes require managed HAProxy files. `content` must be sensitive in Terraform state and excluded from schema fixtures. |
+| `pfsense_haproxy_settings_dns_resolver` | HAProxyDNSResolver | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/settings/dns_resolver` | Create requires `name`, `server`. Patch requires `id`. | Model as settings child only if needed. Pending UAT confirmation of nesting and IDs. |
+| `pfsense_haproxy_settings_email_mailer` | HAProxyEmailMailer | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/settings/email_mailer` | Create requires `name`, `mailserver`. Patch requires `id`. | Model as settings child only if needed. Pending UAT confirmation of nesting and IDs. |
+| `pfsense_haproxy_apply` | HAProxyApply | `GET/POST /api/v2/services/haproxy/apply` | `GET` reports `applied`; `POST` applies pending changes. | Not a durable config resource. Implement as an explicit apply/action workflow after CRUD resources exist. |
+
+## Pending UAT Questions
+
+- Exact response envelope for create/update/delete, including where object IDs are
+  returned.
+- Whether UAT uses numeric IDs, string IDs, or mixed IDs for every HAProxy model.
+- Whether published required fields such as `agent_port` and
+  `persist_cookie_name` are truly required by UAT for backend creation.
+- Whether conditional action fields can be omitted when unrelated to the chosen
+  action.
+- Whether HAProxy and HAProxy-devel expose identical schema paths on this UAT
+  firewall.

--- a/scripts/capture_haproxy_schema.py
+++ b/scripts/capture_haproxy_schema.py
@@ -248,25 +248,45 @@ def capture_metadata(captured_at: str, source_path: str) -> dict[str, str]:
     }
 
 
-def redact(value: Any, key: str = "") -> Any:
+SAFE_SCHEMA_METADATA_KEYS = {
+    "$ref",
+    "description",
+    "format",
+    "items",
+    "nullable",
+    "readOnly",
+    "required",
+    "title",
+    "type",
+    "writeOnly",
+}
+
+
+def redact(value: Any, key: str = "", sensitive_context: bool = False) -> Any:
+    current_sensitive = sensitive_context or bool(key and SENSITIVE_KEY_RE.search(key))
     if isinstance(value, dict):
-        return {item_key: redact(item_value, item_key) for item_key, item_value in value.items()}
+        return {
+            item_key: redact(item_value, item_key, current_sensitive)
+            for item_key, item_value in value.items()
+        }
     if isinstance(value, list):
-        return [redact(item, key) for item in value]
+        return [redact(item, key, current_sensitive) for item in value]
     if isinstance(value, str):
-        if should_redact_string(key, value):
+        if should_redact_string(key, value, current_sensitive):
             return REDACTION_TEXT
         return value
-    if key and SENSITIVE_KEY_RE.search(key) and value is not None:
+    if value is not None and current_sensitive and key not in SAFE_SCHEMA_METADATA_KEYS:
         return REDACTION_TEXT
     return value
 
 
-def should_redact_string(key: str, value: str) -> bool:
+def should_redact_string(key: str, value: str, sensitive_context: bool = False) -> bool:
     stripped = value.strip()
     if not stripped:
         return False
-    if key and SENSITIVE_KEY_RE.search(key) and not looks_like_schema_description(stripped):
+    if key and SENSITIVE_KEY_RE.search(key):
+        return True
+    if sensitive_context and key not in SAFE_SCHEMA_METADATA_KEYS:
         return True
     if PEM_RE.search(stripped):
         return True
@@ -276,11 +296,7 @@ def should_redact_string(key: str, value: str) -> bool:
         return True
     if JWT_RE.match(stripped):
         return True
-    return bool(LONG_TOKEN_RE.match(stripped) and not looks_like_schema_description(stripped))
-
-
-def looks_like_schema_description(value: str) -> bool:
-    return "<br>" in value or " " in value or value.startswith("#/")
+    return bool(LONG_TOKEN_RE.match(stripped))
 
 
 def write_json(path: Path, payload: Any) -> None:

--- a/scripts/capture_haproxy_schema.py
+++ b/scripts/capture_haproxy_schema.py
@@ -313,10 +313,14 @@ def run() -> int:
 
     if args.dry_run:
         display_endpoint = endpoint or "https://pfsense.example.invalid"
-        for schema_name, schema_path in schemas:
-            output_path = output_dir / f"haproxy-{schema_name}.redacted.json"
-            print(f"would fetch {build_url(display_endpoint, schema_path)}")
-            print(f"would write {output_path}")
+        try:
+            for schema_name, schema_path in schemas:
+                output_path = output_dir / f"haproxy-{schema_name}.redacted.json"
+                print(f"would fetch {build_url(display_endpoint, schema_path)}")
+                print(f"would write {output_path}")
+        except ValueError as exc:
+            print(f"invalid PFSENSE_ENDPOINT: {exc}", file=sys.stderr)
+            return 2
         print(f"auth method: {auth_method}")
         print(f"insecure tls: {args.insecure}")
         return 0
@@ -339,8 +343,8 @@ def run() -> int:
 
     captured_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     for schema_name, schema_path in schemas:
-        url = build_url(endpoint, schema_path)
         try:
+            url = build_url(endpoint, schema_path)
             payload = fetch_json(url, headers, args.insecure, timeout)
             if schema_name == "openapi":
                 filtered = filter_openapi_schema(payload, captured_at)

--- a/scripts/capture_haproxy_schema.py
+++ b/scripts/capture_haproxy_schema.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Capture redacted pfSense REST API HAProxy schema metadata.
+
+This script only reads the schema endpoints. It does not call HAProxy config
+CRUD endpoints and does not apply pending HAProxy changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import posixpath
+import re
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+API_PREFIX = "/api/v2"
+HAPROXY_PREFIX = f"{API_PREFIX}/services/haproxy"
+OPENAPI_SCHEMA_PATH = f"{API_PREFIX}/schema/openapi"
+NATIVE_SCHEMA_PATH = f"{API_PREFIX}/schema/native"
+REDACTION_TEXT = "[REDACTED]"
+
+SENSITIVE_KEY_RE = re.compile(
+    r"(^|[_-])(api[_-]?key|authorization|bearer|cert|certificate|client[_-]?cert|"
+    r"credential|jwt|key|p12|passwd|password|private[_-]?key|secret|token)([_-]|$)",
+    re.IGNORECASE,
+)
+HAPROXY_MODEL_RE = re.compile(r"HAProxy[A-Za-z0-9_]*")
+PEM_RE = re.compile(r"-----BEGIN [A-Z0-9 ]+-----")
+JWT_RE = re.compile(r"^[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}$")
+LONG_TOKEN_RE = re.compile(r"^[A-Za-z0-9+/=_-]{80,}$")
+PRIVATE_CONFIG_RE = re.compile(r"<(?:pfsense|config)[\s>]", re.IGNORECASE)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fetch /api/v2/schema/openapi and/or /api/v2/schema/native, filter "
+            "pfSense-pkg-RESTAPI HAProxy metadata, redact sensitive values, and "
+            "write JSON under docs/schema by default."
+        )
+    )
+    parser.add_argument(
+        "--schema",
+        choices=("openapi", "native", "both"),
+        default="both",
+        help="Schema endpoint to capture. Default: both.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="docs/schema",
+        help="Directory for redacted JSON outputs. Default: docs/schema.",
+    )
+    parser.add_argument(
+        "--timeout",
+        default=os.getenv("PFSENSE_TIMEOUT", "30s"),
+        help="HTTP timeout, for example 30s or 5.5. Default: PFSENSE_TIMEOUT or 30s.",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        default=parse_bool(os.getenv("PFSENSE_INSECURE_TLS", "")),
+        help="Skip TLS verification. Default: PFSENSE_INSECURE_TLS.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the planned schema requests and outputs without network access.",
+    )
+    return parser.parse_args()
+
+
+def parse_bool(raw: str) -> bool:
+    return raw.strip().lower() in {"1", "t", "true", "y", "yes", "on"}
+
+
+def parse_timeout(raw: str) -> float:
+    value = raw.strip().lower()
+    if not value:
+        return 30.0
+    multipliers = {"ms": 0.001, "s": 1.0, "m": 60.0}
+    for suffix, multiplier in multipliers.items():
+        if value.endswith(suffix):
+            return float(value[: -len(suffix)]) * multiplier
+    return float(value)
+
+
+def requested_schemas(schema: str) -> list[tuple[str, str]]:
+    if schema == "openapi":
+        return [("openapi", OPENAPI_SCHEMA_PATH)]
+    if schema == "native":
+        return [("native", NATIVE_SCHEMA_PATH)]
+    return [("openapi", OPENAPI_SCHEMA_PATH), ("native", NATIVE_SCHEMA_PATH)]
+
+
+def build_url(endpoint: str, request_path: str) -> str:
+    parsed = urllib.parse.urlparse(endpoint.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("PFSENSE_ENDPOINT must be an absolute http(s) URL")
+
+    base_path = parsed.path.rstrip("/")
+    api_path = "/" + request_path.lstrip("/")
+    if base_path.endswith(API_PREFIX) and api_path.startswith(API_PREFIX):
+        api_path = api_path[len(API_PREFIX) :] or "/"
+
+    if api_path.startswith(API_PREFIX):
+        joined_path = posixpath.join(base_path, api_path.lstrip("/"))
+    elif base_path.endswith(API_PREFIX):
+        joined_path = posixpath.join(base_path, api_path.lstrip("/"))
+    else:
+        joined_path = posixpath.join(base_path, API_PREFIX.lstrip("/"), api_path.lstrip("/"))
+
+    if not joined_path.startswith("/"):
+        joined_path = "/" + joined_path
+
+    return urllib.parse.urlunparse(
+        parsed._replace(path=joined_path, params="", query="", fragment="")
+    )
+
+
+def auth_headers() -> tuple[dict[str, str], str]:
+    api_key = os.getenv("PFSENSE_API_KEY", "").strip()
+    username = os.getenv("PFSENSE_USERNAME", "").strip()
+    password = os.getenv("PFSENSE_PASSWORD", "")
+
+    if api_key:
+        return {"X-API-Key": api_key}, "api_key"
+    if username and password:
+        token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+        return {"Authorization": f"Basic {token}"}, "basic"
+    return {}, "missing"
+
+
+def fetch_json(url: str, headers: dict[str, str], insecure: bool, timeout: float) -> Any:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "terraform-provider-pfsense-restapi-haproxy-schema-capture",
+            **headers,
+        },
+        method="GET",
+    )
+    context = ssl._create_unverified_context() if insecure else None
+    with urllib.request.urlopen(request, timeout=timeout, context=context) as response:
+        body = response.read()
+    return json.loads(body)
+
+
+def collect_refs(value: Any) -> set[str]:
+    refs: set[str] = set()
+    if isinstance(value, dict):
+        ref = value.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/components/schemas/"):
+            refs.add(ref.rsplit("/", 1)[-1])
+        for item in value.values():
+            refs.update(collect_refs(item))
+    elif isinstance(value, list):
+        for item in value:
+            refs.update(collect_refs(item))
+    return refs
+
+
+def filter_openapi_schema(payload: dict[str, Any], captured_at: str) -> dict[str, Any]:
+    paths = {
+        path: value
+        for path, value in sorted(payload.get("paths", {}).items())
+        if path.startswith(HAPROXY_PREFIX)
+    }
+    if not paths:
+        raise ValueError(f"OpenAPI schema did not contain {HAPROXY_PREFIX} paths")
+
+    schemas = payload.get("components", {}).get("schemas", {})
+    selected: set[str] = set()
+    pending = list(collect_refs(paths) | {name for name in schemas if name.startswith("HAProxy")})
+    while pending:
+        name = pending.pop()
+        if name not in schemas or name in selected:
+            continue
+        selected.add(name)
+        pending.extend(collect_refs(schemas[name]) - selected)
+
+    return {
+        "capture": capture_metadata(captured_at, OPENAPI_SCHEMA_PATH),
+        "openapi": payload.get("openapi"),
+        "info": payload.get("info", {}),
+        "paths": paths,
+        "components": {
+            "schemas": {name: schemas[name] for name in sorted(selected) if name in schemas}
+        },
+    }
+
+
+def collect_haproxy_models(value: Any) -> set[str]:
+    models: set[str] = set()
+    if isinstance(value, dict):
+        for item in value.values():
+            models.update(collect_haproxy_models(item))
+    elif isinstance(value, list):
+        for item in value:
+            models.update(collect_haproxy_models(item))
+    elif isinstance(value, str):
+        models.update(HAPROXY_MODEL_RE.findall(value))
+    return models
+
+
+def filter_native_schema(payload: dict[str, Any], captured_at: str) -> dict[str, Any]:
+    endpoints = payload.get("endpoints", {})
+    haproxy_endpoints = {
+        path: value
+        for path, value in sorted(endpoints.items())
+        if "/services/haproxy" in path
+    }
+    if not haproxy_endpoints:
+        raise ValueError("Native schema did not contain /services/haproxy endpoints")
+
+    models = payload.get("models", {})
+    selected_models = {
+        name for name in models if isinstance(name, str) and name.startswith("HAProxy")
+    }
+    selected_models.update(collect_haproxy_models(haproxy_endpoints))
+
+    return {
+        "capture": capture_metadata(captured_at, NATIVE_SCHEMA_PATH),
+        "version": payload.get("version"),
+        "endpoints": haproxy_endpoints,
+        "models": {name: models[name] for name in sorted(selected_models) if name in models},
+    }
+
+
+def capture_metadata(captured_at: str, source_path: str) -> dict[str, str]:
+    return {
+        "captured_at_utc": captured_at,
+        "captured_by": "scripts/capture_haproxy_schema.py",
+        "source_endpoint": REDACTION_TEXT,
+        "source_path": source_path,
+        "filter": f"HAProxy paths containing {HAPROXY_PREFIX} and referenced HAProxy schemas/models",
+        "redaction": "Recursive key/value redaction was applied before writing this file.",
+    }
+
+
+def redact(value: Any, key: str = "") -> Any:
+    if isinstance(value, dict):
+        return {item_key: redact(item_value, item_key) for item_key, item_value in value.items()}
+    if isinstance(value, list):
+        return [redact(item, key) for item in value]
+    if isinstance(value, str):
+        if should_redact_string(key, value):
+            return REDACTION_TEXT
+        return value
+    if key and SENSITIVE_KEY_RE.search(key) and value is not None:
+        return REDACTION_TEXT
+    return value
+
+
+def should_redact_string(key: str, value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if key and SENSITIVE_KEY_RE.search(key) and not looks_like_schema_description(stripped):
+        return True
+    if PEM_RE.search(stripped):
+        return True
+    if PRIVATE_CONFIG_RE.search(stripped):
+        return True
+    if stripped.lower().startswith(("bearer ", "basic ")):
+        return True
+    if JWT_RE.match(stripped):
+        return True
+    return bool(LONG_TOKEN_RE.match(stripped) and not looks_like_schema_description(stripped))
+
+
+def looks_like_schema_description(value: str) -> bool:
+    return "<br>" in value or " " in value or value.startswith("#/")
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run() -> int:
+    args = parse_args()
+    schemas = requested_schemas(args.schema)
+    output_dir = Path(args.output_dir)
+    endpoint = os.getenv("PFSENSE_ENDPOINT", "").strip()
+    headers, auth_method = auth_headers()
+
+    if args.dry_run:
+        display_endpoint = endpoint or "https://pfsense.example.invalid"
+        for schema_name, schema_path in schemas:
+            output_path = output_dir / f"haproxy-{schema_name}.redacted.json"
+            print(f"would fetch {build_url(display_endpoint, schema_path)}")
+            print(f"would write {output_path}")
+        print(f"auth method: {auth_method}")
+        print(f"insecure tls: {args.insecure}")
+        return 0
+
+    if not endpoint:
+        print("PFSENSE_ENDPOINT is required", file=sys.stderr)
+        return 2
+    if auth_method == "missing":
+        print(
+            "Set PFSENSE_API_KEY or PFSENSE_USERNAME/PFSENSE_PASSWORD before capture",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        timeout = parse_timeout(args.timeout)
+    except ValueError as exc:
+        print(f"invalid timeout {args.timeout!r}: {exc}", file=sys.stderr)
+        return 2
+
+    captured_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    for schema_name, schema_path in schemas:
+        url = build_url(endpoint, schema_path)
+        try:
+            payload = fetch_json(url, headers, args.insecure, timeout)
+            if schema_name == "openapi":
+                filtered = filter_openapi_schema(payload, captured_at)
+            else:
+                filtered = filter_native_schema(payload, captured_at)
+            output_path = output_dir / f"haproxy-{schema_name}.redacted.json"
+            write_json(output_path, redact(filtered))
+            print(f"wrote {output_path}")
+        except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError) as exc:
+            print(f"failed to capture {schema_path}: {exc}", file=sys.stderr)
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/scripts/capture_haproxy_schema_test.py
+++ b/scripts/capture_haproxy_schema_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Unit tests for capture_haproxy_schema.py redaction behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("capture_haproxy_schema.py")
+SPEC = importlib.util.spec_from_file_location("capture_haproxy_schema", SCRIPT_PATH)
+assert SPEC is not None
+capture_haproxy_schema = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(capture_haproxy_schema)
+
+
+class RedactionTests(unittest.TestCase):
+    def test_sensitive_scalar_with_spaces_is_redacted(self) -> None:
+        payload = {"api_key": "abc def"}
+
+        self.assertEqual(
+            capture_haproxy_schema.redact(payload),
+            {"api_key": capture_haproxy_schema.REDACTION_TEXT},
+        )
+
+    def test_sensitive_parent_context_redacts_nested_defaults(self) -> None:
+        payload = {
+            "stats_password": {
+                "type": "string",
+                "description": "Password used by HAProxy statistics.",
+                "default": "abc def",
+                "example": "secret with spaces",
+            }
+        }
+
+        self.assertEqual(
+            capture_haproxy_schema.redact(payload),
+            {
+                "stats_password": {
+                    "type": "string",
+                    "description": "Password used by HAProxy statistics.",
+                    "default": capture_haproxy_schema.REDACTION_TEXT,
+                    "example": capture_haproxy_schema.REDACTION_TEXT,
+                }
+            },
+        )
+
+    def test_pem_blocks_are_redacted_without_sensitive_key(self) -> None:
+        payload = {"example": "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----"}
+
+        self.assertEqual(
+            capture_haproxy_schema.redact(payload),
+            {"example": capture_haproxy_schema.REDACTION_TEXT},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/capture_haproxy_schema_test.py
+++ b/scripts/capture_haproxy_schema_test.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
+import subprocess
+import sys
 import unittest
 
 
@@ -54,6 +56,25 @@ class RedactionTests(unittest.TestCase):
             capture_haproxy_schema.redact(payload),
             {"example": capture_haproxy_schema.REDACTION_TEXT},
         )
+
+
+class CLITests(unittest.TestCase):
+    def test_dry_run_invalid_endpoint_returns_user_facing_error(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--dry-run",
+            ],
+            check=False,
+            env={"PFSENSE_ENDPOINT": "not-a-url"},
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("invalid PFSENSE_ENDPOINT", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add a local-only HAProxy schema capture/redaction script for pfSense REST API OpenAPI/native metadata.
- Document HAProxy endpoint inventory from primary pfREST references.
- Document provisional Terraform resource schema decisions and mark live UAT confirmation as pending.
- Record current UAT blocker: schema probes to UAT gateway endpoints timed out from this environment on 2026-04-28.

## Verification
- `python3 scripts/capture_haproxy_schema.py --help`
- `python3 scripts/capture_haproxy_schema.py --dry-run`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/capture_haproxy_schema.py`
- `git diff --check`
- `make lint`
- `make test`

## UAT Status
No live UAT fixture is committed in this PR. The capture workflow is ready, but UAT schema capture is blocked from this environment by connection timeouts to `192.168.51.254` and `192.168.31.254`.

## Cruise Roles
- Implementer: fresh worker agent, commit `5ad4175`
- Tester: local dry-run/py_compile/git diff/lint/test checks
- Consultant: fresh research agent for pfREST schema/endpoint source guidance
- Reviewer: fresh adversarial reviewer before PR ready

Closes #3
