### PR TITLE
feat(provider): harden provider configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Provider arguments can also be supplied with environment variables:
 
 Prefer API key authentication for automation.
 
+`auto_apply` is intentionally not exposed yet. Apply/reload behavior is reserved
+for the planned `pfsense_haproxy_apply` implementation once HAProxy resource
+semantics are in place.
+
 ## Development
 
 ```bash

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -100,9 +101,7 @@ func (p *haproxyProvider) Configure(ctx context.Context, req provider.ConfigureR
 		return
 	}
 
-	if resolved.InsecureTLS {
-		tflog.Warn(ctx, "TLS certificate verification is disabled")
-	}
+	logInsecureTLSWarning(ctx, resolved.InsecureTLS)
 
 	client := pfsense.NewClient(pfsense.Config{
 		Endpoint:    resolved.Endpoint,
@@ -128,13 +127,17 @@ func (p *haproxyProvider) DataSources(_ context.Context) []func() datasource.Dat
 func resolveConfig(config providerConfig) (resolvedConfig, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	endpoint, d := stringOrEnv(config.Endpoint, "PFSENSE_ENDPOINT")
+	endpoint, d := stringOrEnv(config.Endpoint, "endpoint", "PFSENSE_ENDPOINT")
+	endpointHasError := d.HasError()
 	diags.Append(d...)
-	apiKey, d := stringOrEnv(config.APIKey, "PFSENSE_API_KEY")
+	apiKey, d := stringOrEnv(config.APIKey, "api_key", "PFSENSE_API_KEY")
+	apiKeyHasError := d.HasError()
 	diags.Append(d...)
-	username, d := stringOrEnv(config.Username, "PFSENSE_USERNAME")
+	username, d := stringOrEnv(config.Username, "username", "PFSENSE_USERNAME")
+	usernameHasError := d.HasError()
 	diags.Append(d...)
-	password, d := stringOrEnv(config.Password, "PFSENSE_PASSWORD")
+	password, d := stringOrEnv(config.Password, "password", "PFSENSE_PASSWORD")
+	passwordHasError := d.HasError()
 	diags.Append(d...)
 	insecureTLS, d := boolOrEnv(config.InsecureTLS, "PFSENSE_INSECURE_TLS")
 	diags.Append(d...)
@@ -142,15 +145,27 @@ func resolveConfig(config providerConfig) (resolvedConfig, diag.Diagnostics) {
 	timeout, d := durationOrEnv(config.Timeout, "PFSENSE_TIMEOUT", 30*time.Second)
 	diags.Append(d...)
 
-	endpoint = strings.TrimRight(endpoint, "/")
-	if endpoint == "" {
+	endpoint = normalizeEndpoint(endpoint)
+	if endpoint == "" && !endpointHasError {
 		diags.AddError("Missing endpoint", "Set endpoint in the provider configuration or PFSENSE_ENDPOINT environment variable.")
+	} else if endpoint != "" {
+		diags.Append(validateEndpoint(endpoint)...)
 	}
-	if apiKey == "" && (username == "" || password == "") {
-		diags.AddError("Missing authentication", "Set api_key/PFSENSE_API_KEY or username/password via provider configuration or environment variables.")
-	}
-	if apiKey != "" && (username != "" || password != "") {
-		diags.AddWarning("Multiple authentication methods configured", "api_key takes precedence over username/password authentication.")
+
+	if !apiKeyHasError && !usernameHasError && !passwordHasError {
+		if apiKey == "" {
+			switch {
+			case username == "" && password == "":
+				diags.AddError("Missing authentication", "Set api_key/PFSENSE_API_KEY or username/password via provider configuration or environment variables.")
+			case username == "":
+				diags.AddError("Incomplete username/password authentication", "Set username/PFSENSE_USERNAME when password/PFSENSE_PASSWORD is configured, or use api_key/PFSENSE_API_KEY.")
+			case password == "":
+				diags.AddError("Incomplete username/password authentication", "Set password/PFSENSE_PASSWORD when username/PFSENSE_USERNAME is configured, or use api_key/PFSENSE_API_KEY.")
+			}
+		}
+		if apiKey != "" && (username != "" || password != "") {
+			diags.AddWarning("Multiple authentication methods configured", "api_key takes precedence over username/password authentication.")
+		}
 	}
 
 	return resolvedConfig{
@@ -163,10 +178,10 @@ func resolveConfig(config providerConfig) (resolvedConfig, diag.Diagnostics) {
 	}, diags
 }
 
-func stringOrEnv(value types.String, envName string) (string, diag.Diagnostics) {
+func stringOrEnv(value types.String, attrName string, envName string) (string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if value.IsUnknown() {
-		diags.AddError("Invalid configuration", fmt.Sprintf("%s is unknown", envName))
+		diags.AddError("Invalid configuration", fmt.Sprintf("%s is unknown", attrName))
 		return "", diags
 	}
 	if !value.IsNull() {
@@ -217,5 +232,43 @@ func durationOrEnv(value types.String, envName string, fallback time.Duration) (
 		diags.AddError("Invalid timeout", fmt.Sprintf("%q is not a valid duration", raw))
 		return fallback, diags
 	}
+	if parsed <= 0 {
+		diags.AddError("Invalid timeout", "timeout must be greater than zero.")
+		return fallback, diags
+	}
 	return parsed, diags
+}
+
+func normalizeEndpoint(endpoint string) string {
+	return strings.TrimRight(strings.TrimSpace(endpoint), "/")
+}
+
+func validateEndpoint(endpoint string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		diags.AddError("Invalid endpoint", fmt.Sprintf("endpoint must be a valid absolute http(s) URL: %v", err))
+		return diags
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		diags.AddError("Invalid endpoint", "endpoint must be an absolute http(s) URL, for example https://pfsense.example.com.")
+		return diags
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+	default:
+		diags.AddError("Invalid endpoint", fmt.Sprintf("endpoint scheme must be http or https, got %q.", parsed.Scheme))
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		diags.AddError("Invalid endpoint", "endpoint must not include a query string or fragment.")
+	}
+
+	return diags
+}
+
+func logInsecureTLSWarning(ctx context.Context, insecureTLS bool) {
+	if insecureTLS {
+		tflog.Warn(ctx, "TLS certificate verification is disabled")
+	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -255,6 +255,9 @@ func validateEndpoint(endpoint string) diag.Diagnostics {
 		diags.AddError("Invalid endpoint", "endpoint must be an absolute http(s) URL, for example https://pfsense.example.com.")
 		return diags
 	}
+	if parsed.User != nil {
+		diags.AddError("Invalid endpoint", "endpoint must not include embedded username or password credentials; use api_key or username/password provider arguments instead.")
+	}
 	switch parsed.Scheme {
 	case "http", "https":
 	default:

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,15 +1,20 @@
 package provider
 
 import (
+	"bytes"
+	"context"
+	"strings"
 	"testing"
 	"time"
 
+	providerfw "github.com/hashicorp/terraform-plugin-framework/provider"
+	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
 )
 
 func TestResolveConfigAPIKeyFromProvider(t *testing.T) {
-	t.Setenv("PFSENSE_ENDPOINT", "")
-	t.Setenv("PFSENSE_API_KEY", "")
+	clearProviderEnv(t)
 
 	resolved, diags := resolveConfig(providerConfig{
 		Endpoint:    types.StringValue("https://pfsense.example.com/"),
@@ -34,11 +39,69 @@ func TestResolveConfigAPIKeyFromProvider(t *testing.T) {
 	}
 }
 
+func TestResolveConfigEnvironmentFallbackWithExplicitNulls(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("PFSENSE_ENDPOINT", " https://pfsense-env.example.com/ ")
+	t.Setenv("PFSENSE_API_KEY", " env-secret ")
+	t.Setenv("PFSENSE_INSECURE_TLS", "true")
+	t.Setenv("PFSENSE_TIMEOUT", "45s")
+
+	resolved, diags := resolveConfig(providerConfig{
+		Endpoint:    types.StringNull(),
+		APIKey:      types.StringNull(),
+		InsecureTLS: types.BoolNull(),
+		Timeout:     types.StringNull(),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", diags)
+	}
+	if resolved.Endpoint != "https://pfsense-env.example.com" {
+		t.Fatalf("endpoint = %q", resolved.Endpoint)
+	}
+	if resolved.APIKey != "env-secret" {
+		t.Fatalf("api key = %q", resolved.APIKey)
+	}
+	if !resolved.InsecureTLS {
+		t.Fatalf("insecure tls not resolved from environment")
+	}
+	if resolved.Timeout != 45*time.Second {
+		t.Fatalf("timeout = %s", resolved.Timeout)
+	}
+}
+
+func TestResolveConfigProviderValuesOverrideEnvironment(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("PFSENSE_ENDPOINT", "https://pfsense-env.example.com")
+	t.Setenv("PFSENSE_API_KEY", "env-secret")
+	t.Setenv("PFSENSE_INSECURE_TLS", "true")
+	t.Setenv("PFSENSE_TIMEOUT", "45s")
+
+	resolved, diags := resolveConfig(providerConfig{
+		Endpoint:    types.StringValue("https://pfsense-provider.example.com/"),
+		APIKey:      types.StringValue("provider-secret"),
+		InsecureTLS: types.BoolValue(false),
+		Timeout:     types.StringValue("5s"),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", diags)
+	}
+	if resolved.Endpoint != "https://pfsense-provider.example.com" {
+		t.Fatalf("endpoint = %q", resolved.Endpoint)
+	}
+	if resolved.APIKey != "provider-secret" {
+		t.Fatalf("api key = %q", resolved.APIKey)
+	}
+	if resolved.InsecureTLS {
+		t.Fatalf("insecure tls should use provider value")
+	}
+	if resolved.Timeout != 5*time.Second {
+		t.Fatalf("timeout = %s", resolved.Timeout)
+	}
+}
+
 func TestResolveConfigRequiresAuth(t *testing.T) {
+	clearProviderEnv(t)
 	t.Setenv("PFSENSE_ENDPOINT", "https://pfsense.example.com")
-	t.Setenv("PFSENSE_API_KEY", "")
-	t.Setenv("PFSENSE_USERNAME", "")
-	t.Setenv("PFSENSE_PASSWORD", "")
 
 	_, diags := resolveConfig(providerConfig{})
 	if !diags.HasError() {
@@ -47,6 +110,7 @@ func TestResolveConfigRequiresAuth(t *testing.T) {
 }
 
 func TestResolveConfigUsernamePasswordFromEnv(t *testing.T) {
+	clearProviderEnv(t)
 	t.Setenv("PFSENSE_ENDPOINT", "https://pfsense.example.com")
 	t.Setenv("PFSENSE_USERNAME", "api-user")
 	t.Setenv("PFSENSE_PASSWORD", "api-pass")
@@ -62,4 +126,207 @@ func TestResolveConfigUsernamePasswordFromEnv(t *testing.T) {
 	if resolved.Timeout != 45*time.Second {
 		t.Fatalf("timeout = %s", resolved.Timeout)
 	}
+}
+
+func TestResolveConfigRejectsInvalidBoolEnv(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("PFSENSE_ENDPOINT", "https://pfsense.example.com")
+	t.Setenv("PFSENSE_API_KEY", "secret")
+	t.Setenv("PFSENSE_INSECURE_TLS", "not-a-bool")
+
+	_, diags := resolveConfig(providerConfig{})
+	if !diags.HasError() {
+		t.Fatalf("expected invalid boolean diagnostic")
+	}
+}
+
+func TestResolveConfigRejectsInvalidTimeout(t *testing.T) {
+	for _, timeout := range []string{"not-a-duration", "0s", "-1s"} {
+		t.Run(timeout, func(t *testing.T) {
+			clearProviderEnv(t)
+
+			_, diags := resolveConfig(providerConfig{
+				Endpoint: types.StringValue("https://pfsense.example.com"),
+				APIKey:   types.StringValue("secret"),
+				Timeout:  types.StringValue(timeout),
+			})
+			if !diags.HasError() {
+				t.Fatalf("expected invalid timeout diagnostic")
+			}
+		})
+	}
+}
+
+func TestResolveConfigMultipleAuthenticationWarning(t *testing.T) {
+	clearProviderEnv(t)
+
+	_, diags := resolveConfig(providerConfig{
+		Endpoint: types.StringValue("https://pfsense.example.com"),
+		APIKey:   types.StringValue("secret"),
+		Username: types.StringValue("api-user"),
+		Password: types.StringValue("api-pass"),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", diags)
+	}
+	if diags.WarningsCount() != 1 {
+		t.Fatalf("warnings count = %d", diags.WarningsCount())
+	}
+}
+
+func TestResolveConfigPartialUsernamePasswordRequiresBoth(t *testing.T) {
+	tests := map[string]providerConfig{
+		"username only": {
+			Endpoint: types.StringValue("https://pfsense.example.com"),
+			Username: types.StringValue("api-user"),
+		},
+		"password only": {
+			Endpoint: types.StringValue("https://pfsense.example.com"),
+			Password: types.StringValue("api-pass"),
+		},
+	}
+
+	for name, config := range tests {
+		t.Run(name, func(t *testing.T) {
+			clearProviderEnv(t)
+
+			_, diags := resolveConfig(config)
+			if !diags.HasError() {
+				t.Fatalf("expected partial username/password diagnostic")
+			}
+		})
+	}
+}
+
+func TestResolveConfigRejectsInvalidEndpoint(t *testing.T) {
+	for _, endpoint := range []string{
+		"pfsense.example.com",
+		"ftp://pfsense.example.com",
+		"https://",
+		"://pfsense.example.com",
+		"https://pfsense.example.com?query=1",
+		"https://pfsense.example.com#fragment",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			clearProviderEnv(t)
+
+			_, diags := resolveConfig(providerConfig{
+				Endpoint: types.StringValue(endpoint),
+				APIKey:   types.StringValue("secret"),
+			})
+			if !diags.HasError() {
+				t.Fatalf("expected invalid endpoint diagnostic")
+			}
+		})
+	}
+}
+
+func TestResolveConfigUnknownValuesAreDiagnostics(t *testing.T) {
+	tests := map[string]providerConfig{
+		"endpoint": {
+			Endpoint: types.StringUnknown(),
+			APIKey:   types.StringValue("secret"),
+		},
+		"api_key": {
+			Endpoint: types.StringValue("https://pfsense.example.com"),
+			APIKey:   types.StringUnknown(),
+		},
+		"insecure_tls": {
+			Endpoint:    types.StringValue("https://pfsense.example.com"),
+			APIKey:      types.StringValue("secret"),
+			InsecureTLS: types.BoolUnknown(),
+		},
+		"timeout": {
+			Endpoint: types.StringValue("https://pfsense.example.com"),
+			APIKey:   types.StringValue("secret"),
+			Timeout:  types.StringUnknown(),
+		},
+	}
+
+	for name, config := range tests {
+		t.Run(name, func(t *testing.T) {
+			clearProviderEnv(t)
+
+			_, diags := resolveConfig(config)
+			if !diags.HasError() {
+				t.Fatalf("expected unknown value diagnostic")
+			}
+		})
+	}
+}
+
+func TestProviderSchemaSensitiveAttributes(t *testing.T) {
+	schema := providerSchema(t)
+	expectedSensitivity := map[string]bool{
+		"endpoint":     false,
+		"api_key":      true,
+		"username":     false,
+		"password":     true,
+		"insecure_tls": false,
+		"timeout":      false,
+	}
+
+	for name, expected := range expectedSensitivity {
+		attr, ok := schema.Attributes[name]
+		if !ok {
+			t.Fatalf("schema missing %q", name)
+		}
+		if attr.IsSensitive() != expected {
+			t.Fatalf("%s sensitivity = %t", name, attr.IsSensitive())
+		}
+	}
+}
+
+func TestProviderSchemaDoesNotExposeAutoApplyYet(t *testing.T) {
+	schema := providerSchema(t)
+	if _, ok := schema.Attributes["auto_apply"]; ok {
+		t.Fatalf("auto_apply is reserved and should not be exposed until apply semantics are implemented")
+	}
+}
+
+func TestLogInsecureTLSWarning(t *testing.T) {
+	var output bytes.Buffer
+	ctx := tflogtest.RootLogger(context.Background(), &output)
+
+	logInsecureTLSWarning(ctx, true)
+	got := output.String()
+	if !strings.Contains(got, `"@level":"warn"`) {
+		t.Fatalf("expected warn log, got %q", got)
+	}
+	if !strings.Contains(got, `"@message":"TLS certificate verification is disabled"`) {
+		t.Fatalf("expected insecure TLS warning message, got %q", got)
+	}
+
+	output.Reset()
+	logInsecureTLSWarning(ctx, false)
+	if output.Len() != 0 {
+		t.Fatalf("expected no log when insecure_tls is false, got %q", output.String())
+	}
+}
+
+func clearProviderEnv(t *testing.T) {
+	t.Helper()
+
+	for _, name := range []string{
+		"PFSENSE_ENDPOINT",
+		"PFSENSE_API_KEY",
+		"PFSENSE_USERNAME",
+		"PFSENSE_PASSWORD",
+		"PFSENSE_INSECURE_TLS",
+		"PFSENSE_TIMEOUT",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func providerSchema(t *testing.T) providerschema.Schema {
+	t.Helper()
+
+	var resp providerfw.SchemaResponse
+	(&haproxyProvider{}).Schema(context.Background(), providerfw.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema diagnostics: %#v", resp.Diagnostics)
+	}
+
+	return resp.Schema
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -204,6 +204,7 @@ func TestResolveConfigRejectsInvalidEndpoint(t *testing.T) {
 		"ftp://pfsense.example.com",
 		"https://",
 		"://pfsense.example.com",
+		"https://user:pass@pfsense.example.com",
 		"https://pfsense.example.com?query=1",
 		"https://pfsense.example.com#fragment",
 	} {


### PR DESCRIPTION
## Summary
- Harden provider endpoint normalization and validation for absolute `http(s)` URLs.
- Expand environment fallback and provider-over-env precedence coverage.
- Add diagnostics for invalid bool env, invalid/zero/negative timeout, malformed endpoints, missing auth, and partial username/password auth.
- Add tests for multiple-auth warning, insecure TLS warning logging, sensitive schema fields, and reserved `auto_apply` behavior.

## Verification
- `make lint`
- `make test`

## Cruise Roles
- Implementer: fresh worker agent, commit `8147e72`
- Tester: local `make lint` / `make test`, provider unit tests
- Consultant: fresh checklist agent for provider config behavior
- Reviewer: fresh adversarial reviewer before PR ready

Closes #4
