### PR TITLE
M2-01 Implement HAProxy settings ownership model

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ through GitHub issues and milestones.
 ```hcl
 terraform {
   required_providers {
-    pfsense-haproxy = {
+    pfsense = {
       source  = "d3vi1/pfsense-restapi-haproxy"
       version = ">= 0.1.0"
     }
   }
 }
 
-provider "pfsense-haproxy" {
+provider "pfsense" {
   endpoint     = "https://pfsense.example.com"
   api_key      = var.pfsense_api_key
   insecure_tls = true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Terraform provider for managing the pfSense HAProxy package through `pfSense-pkg
 
 ## Status
 
-Bootstrap scaffold is in place. Resource implementation is tracked through GitHub issues and milestones.
+Bootstrap scaffold is in place. `pfsense_haproxy_settings` is implemented with
+an import-first ownership model. Additional HAProxy resources are tracked
+through GitHub issues and milestones.
 
 ## Requirements
 
@@ -49,6 +51,35 @@ Prefer API key authentication for automation.
 for the planned `pfsense_haproxy_apply` implementation once HAProxy resource
 semantics are in place.
 
+## HAProxy settings ownership
+
+`pfsense_haproxy_settings` is split into a data source and a singleton resource:
+
+- `data "pfsense_haproxy_settings"` reads `GET /services/haproxy/settings`.
+- `resource "pfsense_haproxy_settings"` must be imported with fixed ID
+  `settings` before it can manage fields.
+- Resource create intentionally returns a diagnostic and performs no REST API
+  write.
+- Resource update patches changed scalar fields with
+  `PATCH /services/haproxy/settings`.
+- Resource delete removes Terraform state only and performs no REST API call.
+- No HAProxy apply/reload is triggered by this resource.
+
+The current schema exposes documented scalar HAProxy settings only. Nested
+`dns_resolvers` and `email_mailers` are intentionally not managed by this
+resource until child-resource ownership is validated. The `advanced` field is
+marked sensitive because it can contain arbitrary HAProxy global configuration.
+
+Live UAT schema capture is still pending. The field list is based on the
+upstream pfSense-pkg-RESTAPI HAProxy settings model and must be verified against
+the approved UAT firewall before production use.
+
+Import example:
+
+```bash
+terraform import pfsense_haproxy_settings.global settings
+```
+
 ## Development
 
 ```bash
@@ -59,9 +90,12 @@ make testacc
 
 `make testacc` requires real pfSense credentials and must be run only against an approved test target unless the issue explicitly targets production.
 
-## Planned resources
+## Resources
 
 - `pfsense_haproxy_settings`
+
+## Planned resources
+
 - `pfsense_haproxy_backend`
 - `pfsense_haproxy_backend_server`
 - `pfsense_haproxy_frontend`
@@ -89,7 +123,8 @@ resource "pfsense_haproxy_backend_server" "addressvalidator_01" {
 }
 ```
 
-The exact schemas will be finalized from pfSense REST API endpoint responses during Milestone 1.
+Remaining resource schemas will be finalized from approved UAT pfSense REST API
+endpoint responses before production use.
 
 ## Schema inventory
 

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -70,3 +70,9 @@ As of 2026-04-28, live UAT schema capture is blocked from this environment:
 No live UAT fixture is committed for this issue. The endpoint inventory and
 resource decisions in this directory are based on primary pfREST documentation
 and are marked pending UAT confirmation.
+
+For M2-01, `pfsense_haproxy_settings` uses the upstream
+`HAProxySettings.inc` scalar model as a conservative implementation reference:
+Terraform manages only scalar fields, treats `advanced` as sensitive, and does
+not manage nested DNS resolver or email mailer children until UAT confirms their
+ownership model.

--- a/docs/schema/resource-schema-decisions.md
+++ b/docs/schema/resource-schema-decisions.md
@@ -56,8 +56,9 @@ Primary references:
 
 - Confirm the implemented scalar field response names and primitive types for
   `pfsense_haproxy_settings` on the approved UAT firewall.
-- Confirm whether `advanced` is returned and accepted as Base64 text, matching
-  the upstream `Base64Field` model.
+- Confirm `advanced` live behavior on UAT. Upstream pfREST `Base64Field`
+  documentation says API representation is decoded plain text while pfSense
+  stores it encoded internally.
 - Confirm no endpoint-side `apply` default is triggered by
   `PATCH /api/v2/services/haproxy/settings` when no apply control parameter is
   supplied.

--- a/docs/schema/resource-schema-decisions.md
+++ b/docs/schema/resource-schema-decisions.md
@@ -35,7 +35,7 @@ Primary references:
 
 | Terraform resource | API model | Primary endpoints | Documented create/update shape | Decision |
 |--------------------|-----------|-------------------|--------------------------------|----------|
-| `pfsense_haproxy_settings` | HAProxySettings | `GET/PATCH /api/v2/services/haproxy/settings` | Settings patch body is partial; no create/delete. | Singleton resource. Import by fixed ID such as `settings` after UAT confirms response shape. |
+| `pfsense_haproxy_settings` | HAProxySettings | `GET/PATCH /api/v2/services/haproxy/settings` | Settings patch body is partial; no create/delete. | Implemented as split model in M2-01: data source reads settings; resource is singleton import-first with fixed ID `settings`, create blocked, update PATCH only, delete state-only, no apply/reload. |
 | `pfsense_haproxy_backend` | HAProxyBackend | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend`; `GET /backends` | Create requires `name`, `agent_port`, and `persist_cookie_name` in public OpenAPI. Patch requires `id`. | Durable top-level resource. Keep embedded collections read-only or ignored when managed by child resources. |
 | `pfsense_haproxy_backend_server` | HAProxyBackendServer | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/server` | Create requires `parent_id`, `name`, `address`, `port`. Patch requires `parent_id`, `id`. | Child resource under backend. Terraform ID must retain backend API ID and server API ID. |
 | `pfsense_haproxy_backend_acl` | HAProxyBackendACL | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/acl` | Create requires `parent_id`, `name`, `expression`, `value`. Patch requires `parent_id`, `id`. | Child resource under backend. |
@@ -54,6 +54,13 @@ Primary references:
 
 ## Pending UAT Questions
 
+- Confirm the implemented scalar field response names and primitive types for
+  `pfsense_haproxy_settings` on the approved UAT firewall.
+- Confirm whether `advanced` is returned and accepted as Base64 text, matching
+  the upstream `Base64Field` model.
+- Confirm no endpoint-side `apply` default is triggered by
+  `PATCH /api/v2/services/haproxy/settings` when no apply control parameter is
+  supplied.
 - Exact response envelope for create/update/delete, including where object IDs are
   returned.
 - Whether UAT uses numeric IDs, string IDs, or mixed IDs for every HAProxy model.

--- a/examples/haproxy_settings.tf
+++ b/examples/haproxy_settings.tf
@@ -1,0 +1,19 @@
+data "pfsense_haproxy_settings" "current" {}
+
+# Import before managing:
+# terraform import pfsense_haproxy_settings.global settings
+#
+# UAT note: this example uses scalar fields from the documented
+# pfSense-pkg-RESTAPI HAProxySettings model. Validate against the approved UAT
+# firewall before applying to shared or production HAProxy configuration.
+resource "pfsense_haproxy_settings" "global" {
+  enable               = true
+  maxconn              = 2000
+  nbthread             = 1
+  hard_stop_after      = "15m"
+  logfacility          = "local0"
+  loglevel             = "warning"
+  resolver_retries     = 3
+  sslcompatibilitymode = "auto"
+  ssldefaultdhparam    = 2048
+}

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
-    pfsense-haproxy = {
+    pfsense = {
       source = "d3vi1/pfsense-restapi-haproxy"
     }
   }
 }
 
-provider "pfsense-haproxy" {
+provider "pfsense" {
   endpoint     = var.pfsense_endpoint
   api_key      = var.pfsense_api_key
   insecure_tls = true

--- a/internal/provider/haproxy_settings.go
+++ b/internal/provider/haproxy_settings.go
@@ -14,6 +14,10 @@ import (
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -69,7 +73,7 @@ var haproxySettingsAttributes = []settingsAttribute{
 	{Name: "email_to", JSONName: "email_to", Kind: settingsAttributeString, Description: "Recipient email address for HAProxy SMTP alerts."},
 	{Name: "sslcompatibilitymode", JSONName: "sslcompatibilitymode", Kind: settingsAttributeString, Description: "SSL/TLS compatibility mode: auto, modern, intermediate, or old."},
 	{Name: "ssldefaultdhparam", JSONName: "ssldefaultdhparam", Kind: settingsAttributeInt64, Description: "Default Diffie-Hellman parameter size."},
-	{Name: "advanced", JSONName: "advanced", Kind: settingsAttributeString, Description: "Base64-encoded additional HAProxy global settings. This may contain sensitive material.", Sensitive: true},
+	{Name: "advanced", JSONName: "advanced", Kind: settingsAttributeString, Description: "Additional HAProxy global settings as plain text. pfREST stores this field encoded internally but represents it as decoded text through the REST API. This may contain sensitive material.", Sensitive: true},
 	{Name: "enablesync", JSONName: "enablesync", Kind: settingsAttributeBool, Description: "Include HAProxy configuration in pfSense HA sync when configured."},
 }
 
@@ -316,24 +320,27 @@ func haproxySettingsResourceSchemaAttributes() map[string]resourceschema.Attribu
 		switch attribute.Kind {
 		case settingsAttributeBool:
 			attributes[attribute.Name] = resourceschema.BoolAttribute{
-				Optional:    true,
-				Computed:    true,
-				Description: attribute.Description,
-				Sensitive:   attribute.Sensitive,
+				Optional:      true,
+				Computed:      true,
+				Description:   attribute.Description,
+				Sensitive:     attribute.Sensitive,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			}
 		case settingsAttributeInt64:
 			attributes[attribute.Name] = resourceschema.Int64Attribute{
-				Optional:    true,
-				Computed:    true,
-				Description: attribute.Description,
-				Sensitive:   attribute.Sensitive,
+				Optional:      true,
+				Computed:      true,
+				Description:   attribute.Description,
+				Sensitive:     attribute.Sensitive,
+				PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 			}
 		case settingsAttributeString:
 			attributes[attribute.Name] = resourceschema.StringAttribute{
-				Optional:    true,
-				Computed:    true,
-				Description: attribute.Description,
-				Sensitive:   attribute.Sensitive,
+				Optional:      true,
+				Computed:      true,
+				Description:   attribute.Description,
+				Sensitive:     attribute.Sensitive,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			}
 		}
 	}

--- a/internal/provider/haproxy_settings.go
+++ b/internal/provider/haproxy_settings.go
@@ -1,0 +1,628 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	haproxySettingsID   = "settings"
+	haproxySettingsPath = "/services/haproxy/settings"
+)
+
+var (
+	_ datasource.DataSource              = (*haproxySettingsDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*haproxySettingsDataSource)(nil)
+	_ resource.Resource                  = (*haproxySettingsResource)(nil)
+	_ resource.ResourceWithConfigure     = (*haproxySettingsResource)(nil)
+	_ resource.ResourceWithImportState   = (*haproxySettingsResource)(nil)
+)
+
+type settingsAttributeKind string
+
+const (
+	settingsAttributeBool   settingsAttributeKind = "bool"
+	settingsAttributeInt64  settingsAttributeKind = "int64"
+	settingsAttributeString settingsAttributeKind = "string"
+)
+
+type settingsAttribute struct {
+	Name        string
+	JSONName    string
+	Kind        settingsAttributeKind
+	Description string
+	Sensitive   bool
+}
+
+var haproxySettingsAttributes = []settingsAttribute{
+	{Name: "enable", JSONName: "enable", Kind: settingsAttributeBool, Description: "Enable or disable HAProxy on the firewall."},
+	{Name: "maxconn", JSONName: "maxconn", Kind: settingsAttributeInt64, Description: "Maximum per-process number of concurrent connections. Null leaves the pfSense package default in place."},
+	{Name: "nbthread", JSONName: "nbthread", Kind: settingsAttributeInt64, Description: "Number of HAProxy threads to start per process."},
+	{Name: "terminate_on_reload", JSONName: "terminate_on_reload", Kind: settingsAttributeBool, Description: "Immediately stop old HAProxy processes on reload."},
+	{Name: "hard_stop_after", JSONName: "hard_stop_after", Kind: settingsAttributeString, Description: "Maximum time allowed for a clean soft stop, such as 30s, 15m, 3h, or 1d."},
+	{Name: "carpdev", JSONName: "carpdev", Kind: settingsAttributeString, Description: "CARP interface IP to monitor so HAProxy runs only on the MASTER firewall."},
+	{Name: "localstatsport", JSONName: "localstatsport", Kind: settingsAttributeInt64, Description: "Internal port used for the HAProxy stats tab. Null disables local stats."},
+	{Name: "localstats_refreshtime", JSONName: "localstats_refreshtime", Kind: settingsAttributeInt64, Description: "Local stats refresh interval in seconds."},
+	{Name: "localstats_sticktable_refreshtime", JSONName: "localstats_sticktable_refreshtime", Kind: settingsAttributeInt64, Description: "Stick table stats refresh interval in seconds."},
+	{Name: "remotesyslog", JSONName: "remotesyslog", Kind: settingsAttributeString, Description: "Remote syslog destination for HAProxy logs, or /var/run/log for local pfSense logs."},
+	{Name: "logfacility", JSONName: "logfacility", Kind: settingsAttributeString, Description: "Syslog facility used by HAProxy."},
+	{Name: "loglevel", JSONName: "loglevel", Kind: settingsAttributeString, Description: "Minimum HAProxy log level to emit."},
+	{Name: "log_send_hostname", JSONName: "log-send-hostname", Kind: settingsAttributeString, Description: "Hostname included in HAProxy syslog headers. Empty uses the system hostname."},
+	{Name: "resolver_retries", JSONName: "resolver_retries", Kind: settingsAttributeInt64, Description: "Number of DNS queries HAProxy sends before giving up."},
+	{Name: "resolver_timeoutretry", JSONName: "resolver_timeoutretry", Kind: settingsAttributeString, Description: "Time between DNS retry queries when no response is received."},
+	{Name: "resolver_holdvalid", JSONName: "resolver_holdvalid", Kind: settingsAttributeString, Description: "Interval between successive name resolutions after a valid answer."},
+	{Name: "email_level", JSONName: "email_level", Kind: settingsAttributeString, Description: "Maximum log level for SMTP alerts. Empty disables email alerts."},
+	{Name: "email_myhostname", JSONName: "email_myhostname", Kind: settingsAttributeString, Description: "Hostname HAProxy uses as the email origin."},
+	{Name: "email_from", JSONName: "email_from", Kind: settingsAttributeString, Description: "Sender email address for HAProxy SMTP alerts."},
+	{Name: "email_to", JSONName: "email_to", Kind: settingsAttributeString, Description: "Recipient email address for HAProxy SMTP alerts."},
+	{Name: "sslcompatibilitymode", JSONName: "sslcompatibilitymode", Kind: settingsAttributeString, Description: "SSL/TLS compatibility mode: auto, modern, intermediate, or old."},
+	{Name: "ssldefaultdhparam", JSONName: "ssldefaultdhparam", Kind: settingsAttributeInt64, Description: "Default Diffie-Hellman parameter size."},
+	{Name: "advanced", JSONName: "advanced", Kind: settingsAttributeString, Description: "Base64-encoded additional HAProxy global settings. This may contain sensitive material.", Sensitive: true},
+	{Name: "enablesync", JSONName: "enablesync", Kind: settingsAttributeBool, Description: "Include HAProxy configuration in pfSense HA sync when configured."},
+}
+
+type haproxySettingsDataSource struct {
+	client *pfsense.Client
+}
+
+type haproxySettingsResource struct {
+	client *pfsense.Client
+}
+
+type haproxySettingsModel struct {
+	ID                              types.String `tfsdk:"id"`
+	Enable                          types.Bool   `tfsdk:"enable"`
+	Maxconn                         types.Int64  `tfsdk:"maxconn"`
+	Nbthread                        types.Int64  `tfsdk:"nbthread"`
+	TerminateOnReload               types.Bool   `tfsdk:"terminate_on_reload"`
+	HardStopAfter                   types.String `tfsdk:"hard_stop_after"`
+	Carpdev                         types.String `tfsdk:"carpdev"`
+	LocalStatsPort                  types.Int64  `tfsdk:"localstatsport"`
+	LocalStatsRefreshTime           types.Int64  `tfsdk:"localstats_refreshtime"`
+	LocalStatsStickTableRefreshTime types.Int64  `tfsdk:"localstats_sticktable_refreshtime"`
+	RemoteSyslog                    types.String `tfsdk:"remotesyslog"`
+	LogFacility                     types.String `tfsdk:"logfacility"`
+	LogLevel                        types.String `tfsdk:"loglevel"`
+	LogSendHostname                 types.String `tfsdk:"log_send_hostname"`
+	ResolverRetries                 types.Int64  `tfsdk:"resolver_retries"`
+	ResolverTimeoutRetry            types.String `tfsdk:"resolver_timeoutretry"`
+	ResolverHoldValid               types.String `tfsdk:"resolver_holdvalid"`
+	EmailLevel                      types.String `tfsdk:"email_level"`
+	EmailMyHostname                 types.String `tfsdk:"email_myhostname"`
+	EmailFrom                       types.String `tfsdk:"email_from"`
+	EmailTo                         types.String `tfsdk:"email_to"`
+	SSLCompatibilityMode            types.String `tfsdk:"sslcompatibilitymode"`
+	SSLDefaultDHParam               types.Int64  `tfsdk:"ssldefaultdhparam"`
+	Advanced                        types.String `tfsdk:"advanced"`
+	EnableSync                      types.Bool   `tfsdk:"enablesync"`
+}
+
+func newHaproxySettingsDataSource() datasource.DataSource {
+	return &haproxySettingsDataSource{}
+}
+
+func newHaproxySettingsResource() resource.Resource {
+	return &haproxySettingsResource{}
+}
+
+func (d *haproxySettingsDataSource) Metadata(_ context.Context, _ datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "pfsense_haproxy_settings"
+}
+
+func (d *haproxySettingsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = datasourceschema.Schema{
+		Description: "Reads the singleton pfSense HAProxy package settings object.",
+		Attributes:  haproxySettingsDataSourceSchemaAttributes(),
+	}
+}
+
+func (d *haproxySettingsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*pfsense.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected data source configure type", fmt.Sprintf("Expected *pfsense.Client, got %T.", req.ProviderData))
+		return
+	}
+
+	d.client = client
+}
+
+func (d *haproxySettingsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if d.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before reading pfsense_haproxy_settings.")
+		return
+	}
+
+	settings, err := readHaproxySettings(ctx, d.client)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy settings failed", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, settings)...)
+}
+
+func (r *haproxySettingsResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "pfsense_haproxy_settings"
+}
+
+func (r *haproxySettingsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resourceschema.Schema{
+		Description: "Manages selected scalar fields from the singleton pfSense HAProxy package settings object. The resource is import-first and never creates or deletes the remote settings object.",
+		Attributes:  haproxySettingsResourceSchemaAttributes(),
+	}
+}
+
+func (r *haproxySettingsResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*pfsense.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected resource configure type", fmt.Sprintf("Expected *pfsense.Client, got %T.", req.ProviderData))
+		return
+	}
+
+	r.client = client
+}
+
+func (r *haproxySettingsResource) Create(_ context.Context, _ resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.Diagnostics.AddError(
+		"Import required for HAProxy settings",
+		"pfsense_haproxy_settings is a singleton settings object that already exists on pfSense. Import it with ID \"settings\" before managing selected fields. Create makes no pfSense REST API write.",
+	)
+}
+
+func (r *haproxySettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before reading pfsense_haproxy_settings.")
+		return
+	}
+
+	var state haproxySettingsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !state.ID.IsNull() && !state.ID.IsUnknown() && state.ID.ValueString() != haproxySettingsID {
+		resp.Diagnostics.AddError("Invalid HAProxy settings ID", fmt.Sprintf("Expected ID %q, got %q.", haproxySettingsID, state.ID.ValueString()))
+		return
+	}
+
+	settings, err := readHaproxySettings(ctx, r.client)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy settings failed", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, settings)...)
+}
+
+func (r *haproxySettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before updating pfsense_haproxy_settings.")
+		return
+	}
+
+	var plan, prior haproxySettingsModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !plan.ID.IsNull() && !plan.ID.IsUnknown() && plan.ID.ValueString() != haproxySettingsID {
+		resp.Diagnostics.AddError("Invalid HAProxy settings ID", fmt.Sprintf("Expected ID %q, got %q.", haproxySettingsID, plan.ID.ValueString()))
+		return
+	}
+	if !prior.ID.IsNull() && !prior.ID.IsUnknown() && prior.ID.ValueString() != haproxySettingsID {
+		resp.Diagnostics.AddError("Invalid HAProxy settings ID", fmt.Sprintf("Expected ID %q, got %q.", haproxySettingsID, prior.ID.ValueString()))
+		return
+	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	patch := buildHaproxySettingsPatch(plan, prior)
+	if len(patch) > 0 {
+		if err := r.client.Patch(ctx, haproxySettingsPath, patch, nil); err != nil {
+			resp.Diagnostics.AddError("Update HAProxy settings failed", err.Error())
+			return
+		}
+	}
+
+	settings, err := readHaproxySettings(ctx, r.client)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy settings after update failed", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, settings)...)
+}
+
+func (r *haproxySettingsResource) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *haproxySettingsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	if req.ID != haproxySettingsID {
+		resp.Diagnostics.AddError("Invalid HAProxy settings import ID", fmt.Sprintf("Import pfsense_haproxy_settings with the fixed ID %q.", haproxySettingsID))
+		return
+	}
+
+	settings := nullHaproxySettingsModel()
+	settings.ID = types.StringValue(haproxySettingsID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, settings)...)
+}
+
+func haproxySettingsDataSourceSchemaAttributes() map[string]datasourceschema.Attribute {
+	attributes := map[string]datasourceschema.Attribute{
+		"id": datasourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Fixed singleton ID for the HAProxy settings object.",
+		},
+	}
+
+	for _, attribute := range haproxySettingsAttributes {
+		switch attribute.Kind {
+		case settingsAttributeBool:
+			attributes[attribute.Name] = datasourceschema.BoolAttribute{
+				Computed:    true,
+				Description: attribute.Description,
+				Sensitive:   attribute.Sensitive,
+			}
+		case settingsAttributeInt64:
+			attributes[attribute.Name] = datasourceschema.Int64Attribute{
+				Computed:    true,
+				Description: attribute.Description,
+				Sensitive:   attribute.Sensitive,
+			}
+		case settingsAttributeString:
+			attributes[attribute.Name] = datasourceschema.StringAttribute{
+				Computed:    true,
+				Description: attribute.Description,
+				Sensitive:   attribute.Sensitive,
+			}
+		}
+	}
+
+	return attributes
+}
+
+func haproxySettingsResourceSchemaAttributes() map[string]resourceschema.Attribute {
+	attributes := map[string]resourceschema.Attribute{
+		"id": resourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Fixed singleton ID for the HAProxy settings object. Import must use \"settings\".",
+		},
+	}
+
+	for _, attribute := range haproxySettingsAttributes {
+		switch attribute.Kind {
+		case settingsAttributeBool:
+			attributes[attribute.Name] = resourceschema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: attribute.Description,
+				Sensitive:   attribute.Sensitive,
+			}
+		case settingsAttributeInt64:
+			attributes[attribute.Name] = resourceschema.Int64Attribute{
+				Optional:    true,
+				Computed:    true,
+				Description: attribute.Description,
+				Sensitive:   attribute.Sensitive,
+			}
+		case settingsAttributeString:
+			attributes[attribute.Name] = resourceschema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: attribute.Description,
+				Sensitive:   attribute.Sensitive,
+			}
+		}
+	}
+
+	return attributes
+}
+
+func readHaproxySettings(ctx context.Context, client *pfsense.Client) (haproxySettingsModel, error) {
+	var payload map[string]any
+	if err := client.Get(ctx, haproxySettingsPath, &payload); err != nil {
+		return haproxySettingsModel{}, err
+	}
+
+	return haproxySettingsModelFromAPI(payload)
+}
+
+func haproxySettingsModelFromAPI(payload map[string]any) (haproxySettingsModel, error) {
+	settings := nullHaproxySettingsModel()
+	settings.ID = types.StringValue(haproxySettingsID)
+
+	var err error
+	if settings.Enable, err = apiBool(payload, "enable"); err != nil {
+		return settings, err
+	}
+	if settings.Maxconn, err = apiInt64(payload, "maxconn"); err != nil {
+		return settings, err
+	}
+	if settings.Nbthread, err = apiInt64(payload, "nbthread"); err != nil {
+		return settings, err
+	}
+	if settings.TerminateOnReload, err = apiBool(payload, "terminate_on_reload"); err != nil {
+		return settings, err
+	}
+	if settings.HardStopAfter, err = apiString(payload, "hard_stop_after"); err != nil {
+		return settings, err
+	}
+	if settings.Carpdev, err = apiString(payload, "carpdev"); err != nil {
+		return settings, err
+	}
+	if settings.LocalStatsPort, err = apiInt64(payload, "localstatsport"); err != nil {
+		return settings, err
+	}
+	if settings.LocalStatsRefreshTime, err = apiInt64(payload, "localstats_refreshtime"); err != nil {
+		return settings, err
+	}
+	if settings.LocalStatsStickTableRefreshTime, err = apiInt64(payload, "localstats_sticktable_refreshtime"); err != nil {
+		return settings, err
+	}
+	if settings.RemoteSyslog, err = apiString(payload, "remotesyslog"); err != nil {
+		return settings, err
+	}
+	if settings.LogFacility, err = apiString(payload, "logfacility"); err != nil {
+		return settings, err
+	}
+	if settings.LogLevel, err = apiString(payload, "loglevel"); err != nil {
+		return settings, err
+	}
+	if settings.LogSendHostname, err = apiString(payload, "log-send-hostname", "log_send_hostname"); err != nil {
+		return settings, err
+	}
+	if settings.ResolverRetries, err = apiInt64(payload, "resolver_retries"); err != nil {
+		return settings, err
+	}
+	if settings.ResolverTimeoutRetry, err = apiString(payload, "resolver_timeoutretry"); err != nil {
+		return settings, err
+	}
+	if settings.ResolverHoldValid, err = apiString(payload, "resolver_holdvalid"); err != nil {
+		return settings, err
+	}
+	if settings.EmailLevel, err = apiString(payload, "email_level"); err != nil {
+		return settings, err
+	}
+	if settings.EmailMyHostname, err = apiString(payload, "email_myhostname"); err != nil {
+		return settings, err
+	}
+	if settings.EmailFrom, err = apiString(payload, "email_from"); err != nil {
+		return settings, err
+	}
+	if settings.EmailTo, err = apiString(payload, "email_to"); err != nil {
+		return settings, err
+	}
+	if settings.SSLCompatibilityMode, err = apiString(payload, "sslcompatibilitymode"); err != nil {
+		return settings, err
+	}
+	if settings.SSLDefaultDHParam, err = apiInt64(payload, "ssldefaultdhparam"); err != nil {
+		return settings, err
+	}
+	if settings.Advanced, err = apiString(payload, "advanced"); err != nil {
+		return settings, err
+	}
+	if settings.EnableSync, err = apiBool(payload, "enablesync"); err != nil {
+		return settings, err
+	}
+
+	return settings, nil
+}
+
+func nullHaproxySettingsModel() haproxySettingsModel {
+	return haproxySettingsModel{
+		ID:                              types.StringNull(),
+		Enable:                          types.BoolNull(),
+		Maxconn:                         types.Int64Null(),
+		Nbthread:                        types.Int64Null(),
+		TerminateOnReload:               types.BoolNull(),
+		HardStopAfter:                   types.StringNull(),
+		Carpdev:                         types.StringNull(),
+		LocalStatsPort:                  types.Int64Null(),
+		LocalStatsRefreshTime:           types.Int64Null(),
+		LocalStatsStickTableRefreshTime: types.Int64Null(),
+		RemoteSyslog:                    types.StringNull(),
+		LogFacility:                     types.StringNull(),
+		LogLevel:                        types.StringNull(),
+		LogSendHostname:                 types.StringNull(),
+		ResolverRetries:                 types.Int64Null(),
+		ResolverTimeoutRetry:            types.StringNull(),
+		ResolverHoldValid:               types.StringNull(),
+		EmailLevel:                      types.StringNull(),
+		EmailMyHostname:                 types.StringNull(),
+		EmailFrom:                       types.StringNull(),
+		EmailTo:                         types.StringNull(),
+		SSLCompatibilityMode:            types.StringNull(),
+		SSLDefaultDHParam:               types.Int64Null(),
+		Advanced:                        types.StringNull(),
+		EnableSync:                      types.BoolNull(),
+	}
+}
+
+func buildHaproxySettingsPatch(plan haproxySettingsModel, prior haproxySettingsModel) map[string]any {
+	patch := make(map[string]any)
+	planValues := plan.attrValues()
+	priorValues := prior.attrValues()
+
+	for _, attribute := range haproxySettingsAttributes {
+		planned := planValues[attribute.Name]
+		if planned.IsUnknown() {
+			continue
+		}
+		if planned.Equal(priorValues[attribute.Name]) {
+			continue
+		}
+
+		patch[attribute.JSONName] = terraformValueToJSON(attribute.Kind, planned)
+	}
+
+	return patch
+}
+
+func (m haproxySettingsModel) attrValues() map[string]attr.Value {
+	return map[string]attr.Value{
+		"enable":                            m.Enable,
+		"maxconn":                           m.Maxconn,
+		"nbthread":                          m.Nbthread,
+		"terminate_on_reload":               m.TerminateOnReload,
+		"hard_stop_after":                   m.HardStopAfter,
+		"carpdev":                           m.Carpdev,
+		"localstatsport":                    m.LocalStatsPort,
+		"localstats_refreshtime":            m.LocalStatsRefreshTime,
+		"localstats_sticktable_refreshtime": m.LocalStatsStickTableRefreshTime,
+		"remotesyslog":                      m.RemoteSyslog,
+		"logfacility":                       m.LogFacility,
+		"loglevel":                          m.LogLevel,
+		"log_send_hostname":                 m.LogSendHostname,
+		"resolver_retries":                  m.ResolverRetries,
+		"resolver_timeoutretry":             m.ResolverTimeoutRetry,
+		"resolver_holdvalid":                m.ResolverHoldValid,
+		"email_level":                       m.EmailLevel,
+		"email_myhostname":                  m.EmailMyHostname,
+		"email_from":                        m.EmailFrom,
+		"email_to":                          m.EmailTo,
+		"sslcompatibilitymode":              m.SSLCompatibilityMode,
+		"ssldefaultdhparam":                 m.SSLDefaultDHParam,
+		"advanced":                          m.Advanced,
+		"enablesync":                        m.EnableSync,
+	}
+}
+
+func terraformValueToJSON(kind settingsAttributeKind, value attr.Value) any {
+	if value.IsNull() {
+		return nil
+	}
+
+	switch kind {
+	case settingsAttributeBool:
+		return value.(types.Bool).ValueBool()
+	case settingsAttributeInt64:
+		return value.(types.Int64).ValueInt64()
+	case settingsAttributeString:
+		return value.(types.String).ValueString()
+	default:
+		return nil
+	}
+}
+
+func apiBool(payload map[string]any, names ...string) (types.Bool, error) {
+	value, name, ok := apiValue(payload, names...)
+	if !ok || value == nil {
+		return types.BoolNull(), nil
+	}
+
+	switch typed := value.(type) {
+	case bool:
+		return types.BoolValue(typed), nil
+	case string:
+		switch strings.ToLower(strings.TrimSpace(typed)) {
+		case "1", "true", "yes", "on":
+			return types.BoolValue(true), nil
+		case "0", "false", "no", "off", "":
+			return types.BoolValue(false), nil
+		default:
+			return types.BoolNull(), fmt.Errorf("HAProxy settings field %q is %q, not a boolean", name, typed)
+		}
+	case float64:
+		if typed == 0 {
+			return types.BoolValue(false), nil
+		}
+		if typed == 1 {
+			return types.BoolValue(true), nil
+		}
+		return types.BoolNull(), fmt.Errorf("HAProxy settings field %q is %v, not a boolean", name, typed)
+	case json.Number:
+		intValue, err := typed.Int64()
+		if err != nil {
+			return types.BoolNull(), fmt.Errorf("HAProxy settings field %q is %q, not a boolean: %w", name, typed.String(), err)
+		}
+		if intValue == 0 {
+			return types.BoolValue(false), nil
+		}
+		if intValue == 1 {
+			return types.BoolValue(true), nil
+		}
+		return types.BoolNull(), fmt.Errorf("HAProxy settings field %q is %q, not a boolean", name, typed.String())
+	default:
+		return types.BoolNull(), fmt.Errorf("HAProxy settings field %q has unsupported boolean type %T", name, value)
+	}
+}
+
+func apiInt64(payload map[string]any, names ...string) (types.Int64, error) {
+	value, name, ok := apiValue(payload, names...)
+	if !ok || value == nil {
+		return types.Int64Null(), nil
+	}
+
+	switch typed := value.(type) {
+	case float64:
+		if math.Trunc(typed) != typed {
+			return types.Int64Null(), fmt.Errorf("HAProxy settings field %q is %v, not an integer", name, typed)
+		}
+		return types.Int64Value(int64(typed)), nil
+	case json.Number:
+		intValue, err := typed.Int64()
+		if err != nil {
+			return types.Int64Null(), fmt.Errorf("HAProxy settings field %q is %q, not an integer: %w", name, typed.String(), err)
+		}
+		return types.Int64Value(intValue), nil
+	case string:
+		if strings.TrimSpace(typed) == "" {
+			return types.Int64Null(), nil
+		}
+		intValue, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+		if err != nil {
+			return types.Int64Null(), fmt.Errorf("HAProxy settings field %q is %q, not an integer: %w", name, typed, err)
+		}
+		return types.Int64Value(intValue), nil
+	default:
+		return types.Int64Null(), fmt.Errorf("HAProxy settings field %q has unsupported integer type %T", name, value)
+	}
+}
+
+func apiString(payload map[string]any, names ...string) (types.String, error) {
+	value, name, ok := apiValue(payload, names...)
+	if !ok || value == nil {
+		return types.StringNull(), nil
+	}
+
+	typed, ok := value.(string)
+	if !ok {
+		return types.StringNull(), fmt.Errorf("HAProxy settings field %q has unsupported string type %T", name, value)
+	}
+
+	return types.StringValue(typed), nil
+}
+
+func apiValue(payload map[string]any, names ...string) (any, string, bool) {
+	for _, name := range names {
+		value, ok := payload[name]
+		if ok {
+			return value, name, true
+		}
+	}
+
+	return nil, "", false
+}

--- a/internal/provider/haproxy_settings.go
+++ b/internal/provider/haproxy_settings.go
@@ -14,10 +14,6 @@ import (
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -63,7 +59,7 @@ var haproxySettingsAttributes = []settingsAttribute{
 	{Name: "remotesyslog", JSONName: "remotesyslog", Kind: settingsAttributeString, Description: "Remote syslog destination for HAProxy logs, or /var/run/log for local pfSense logs."},
 	{Name: "logfacility", JSONName: "logfacility", Kind: settingsAttributeString, Description: "Syslog facility used by HAProxy."},
 	{Name: "loglevel", JSONName: "loglevel", Kind: settingsAttributeString, Description: "Minimum HAProxy log level to emit."},
-	{Name: "log_send_hostname", JSONName: "log-send-hostname", Kind: settingsAttributeString, Description: "Hostname included in HAProxy syslog headers. Empty uses the system hostname."},
+	{Name: "log_send_hostname", JSONName: "log_send_hostname", Kind: settingsAttributeString, Description: "Hostname included in HAProxy syslog headers. Empty uses the system hostname."},
 	{Name: "resolver_retries", JSONName: "resolver_retries", Kind: settingsAttributeInt64, Description: "Number of DNS queries HAProxy sends before giving up."},
 	{Name: "resolver_timeoutretry", JSONName: "resolver_timeoutretry", Kind: settingsAttributeString, Description: "Time between DNS retry queries when no response is received."},
 	{Name: "resolver_holdvalid", JSONName: "resolver_holdvalid", Kind: settingsAttributeString, Description: "Interval between successive name resolutions after a valid answer."},
@@ -320,27 +316,24 @@ func haproxySettingsResourceSchemaAttributes() map[string]resourceschema.Attribu
 		switch attribute.Kind {
 		case settingsAttributeBool:
 			attributes[attribute.Name] = resourceschema.BoolAttribute{
-				Optional:      true,
-				Computed:      true,
-				Description:   attribute.Description,
-				Sensitive:     attribute.Sensitive,
-				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+				Optional:    true,
+				Computed:    true,
+				Description: attribute.Description,
+				Sensitive:   attribute.Sensitive,
 			}
 		case settingsAttributeInt64:
 			attributes[attribute.Name] = resourceschema.Int64Attribute{
-				Optional:      true,
-				Computed:      true,
-				Description:   attribute.Description,
-				Sensitive:     attribute.Sensitive,
-				PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
+				Optional:    true,
+				Computed:    true,
+				Description: attribute.Description,
+				Sensitive:   attribute.Sensitive,
 			}
 		case settingsAttributeString:
 			attributes[attribute.Name] = resourceschema.StringAttribute{
-				Optional:      true,
-				Computed:      true,
-				Description:   attribute.Description,
-				Sensitive:     attribute.Sensitive,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				Optional:    true,
+				Computed:    true,
+				Description: attribute.Description,
+				Sensitive:   attribute.Sensitive,
 			}
 		}
 	}

--- a/internal/provider/haproxy_settings_test.go
+++ b/internal/provider/haproxy_settings_test.go
@@ -59,7 +59,7 @@ func TestHaproxySettingsDataSourceReadUsesGET(t *testing.T) {
 				"hard_stop_after": "15m",
 				"localstatsport": "8404",
 				"log-send-hostname": "fw-uat",
-				"advanced": "Z2xvYmFsCg==",
+				"advanced": "global\n  tune.ssl.default-dh-param 2048\n",
 				"dns_resolvers": [{"name": "ignored"}],
 				"email_mailers": [{"name": "ignored"}]
 			}
@@ -108,7 +108,7 @@ func TestHaproxySettingsDataSourceReadUsesGET(t *testing.T) {
 	if state.LogSendHostname.ValueString() != "fw-uat" {
 		t.Fatalf("log_send_hostname = %q", state.LogSendHostname.ValueString())
 	}
-	if state.Advanced.ValueString() != "Z2xvYmFsCg==" {
+	if state.Advanced.ValueString() != "global\n  tune.ssl.default-dh-param 2048\n" {
 		t.Fatalf("advanced not read")
 	}
 }
@@ -199,7 +199,7 @@ func TestHaproxySettingsResourceUpdatePatchesChangedFieldsOnly(t *testing.T) {
 					"enable": true,
 					"maxconn": 250,
 					"log-send-hostname": "fw-uat",
-					"advanced": "dW5jaGFuZ2Vk"
+					"advanced": "unchanged advanced text"
 				}
 			}`))
 		default:
@@ -218,7 +218,7 @@ func TestHaproxySettingsResourceUpdatePatchesChangedFieldsOnly(t *testing.T) {
 	prior.Enable = types.BoolValue(false)
 	prior.Maxconn = types.Int64Value(100)
 	prior.LogSendHostname = types.StringValue("")
-	prior.Advanced = types.StringValue("dW5jaGFuZ2Vk")
+	prior.Advanced = types.StringValue("unchanged advanced text")
 
 	plan := prior
 	plan.Enable = types.BoolValue(true)

--- a/internal/provider/haproxy_settings_test.go
+++ b/internal/provider/haproxy_settings_test.go
@@ -253,10 +253,10 @@ func TestHaproxySettingsResourceUpdatePatchesChangedFieldsOnly(t *testing.T) {
 	if patchPayload["maxconn"] != float64(250) {
 		t.Fatalf("maxconn patch = %#v", patchPayload["maxconn"])
 	}
-	if patchPayload["log-send-hostname"] != "fw-uat" {
-		t.Fatalf("log-send-hostname patch = %#v", patchPayload["log-send-hostname"])
+	if patchPayload["log_send_hostname"] != "fw-uat" {
+		t.Fatalf("log_send_hostname patch = %#v", patchPayload["log_send_hostname"])
 	}
-	for _, forbidden := range []string{"advanced", "apply", "async", "dns_resolvers", "email_mailers"} {
+	for _, forbidden := range []string{"advanced", "apply", "async", "dns_resolvers", "email_mailers", "log-send-hostname"} {
 		if _, ok := patchPayload[forbidden]; ok {
 			t.Fatalf("patch unexpectedly included %q: %#v", forbidden, patchPayload)
 		}

--- a/internal/provider/haproxy_settings_test.go
+++ b/internal/provider/haproxy_settings_test.go
@@ -1,0 +1,405 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestProviderRegistersHaproxySettings(t *testing.T) {
+	provider := &haproxyProvider{}
+
+	resources := provider.Resources(context.Background())
+	if !resourceTypeRegistered(resources, "pfsense_haproxy_settings") {
+		t.Fatalf("pfsense_haproxy_settings resource was not registered")
+	}
+
+	dataSources := provider.DataSources(context.Background())
+	if !dataSourceTypeRegistered(dataSources, "pfsense_haproxy_settings") {
+		t.Fatalf("pfsense_haproxy_settings data source was not registered")
+	}
+}
+
+func TestHaproxySettingsDataSourceReadUsesGET(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if r.URL.RequestURI() != "/api/v2/services/haproxy/settings" {
+			t.Fatalf("request uri = %s", r.URL.RequestURI())
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"code": 200,
+			"status": "ok",
+			"data": {
+				"enable": true,
+				"maxconn": 200,
+				"nbthread": "2",
+				"terminate_on_reload": "yes",
+				"hard_stop_after": "15m",
+				"localstatsport": "8404",
+				"log-send-hostname": "fw-uat",
+				"advanced": "Z2xvYmFsCg==",
+				"dns_resolvers": [{"name": "ignored"}],
+				"email_mailers": [{"name": "ignored"}]
+			}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	settingsDataSource := &haproxySettingsDataSource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	resp := datasource.ReadResponse{
+		State: tfsdk.State{Schema: haproxySettingsDataSourceSchema(t)},
+	}
+
+	settingsDataSource.Read(context.Background(), datasource.ReadRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("requests = %d", requests.Load())
+	}
+
+	var state haproxySettingsModel
+	diags := resp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.ID.ValueString() != haproxySettingsID {
+		t.Fatalf("id = %q", state.ID.ValueString())
+	}
+	if !state.Enable.ValueBool() {
+		t.Fatalf("enable not read")
+	}
+	if state.Maxconn.ValueInt64() != 200 {
+		t.Fatalf("maxconn = %d", state.Maxconn.ValueInt64())
+	}
+	if state.Nbthread.ValueInt64() != 2 {
+		t.Fatalf("nbthread = %d", state.Nbthread.ValueInt64())
+	}
+	if !state.TerminateOnReload.ValueBool() {
+		t.Fatalf("terminate_on_reload not read")
+	}
+	if state.LocalStatsPort.ValueInt64() != 8404 {
+		t.Fatalf("localstatsport = %d", state.LocalStatsPort.ValueInt64())
+	}
+	if state.LogSendHostname.ValueString() != "fw-uat" {
+		t.Fatalf("log_send_hostname = %q", state.LogSendHostname.ValueString())
+	}
+	if state.Advanced.ValueString() != "Z2xvYmFsCg==" {
+		t.Fatalf("advanced not read")
+	}
+}
+
+func TestHaproxySettingsResourceImportRequiresFixedID(t *testing.T) {
+	t.Parallel()
+
+	settingsResource := &haproxySettingsResource{}
+	schema := haproxySettingsResourceSchema(t)
+
+	validResp := resource.ImportStateResponse{
+		State: tfsdk.State{Schema: schema},
+	}
+	settingsResource.ImportState(context.Background(), resource.ImportStateRequest{ID: haproxySettingsID}, &validResp)
+	if validResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", validResp.Diagnostics)
+	}
+	var state haproxySettingsModel
+	diags := validResp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.ID.ValueString() != haproxySettingsID {
+		t.Fatalf("imported id = %q", state.ID.ValueString())
+	}
+
+	invalidResp := resource.ImportStateResponse{
+		State: tfsdk.State{Schema: schema},
+	}
+	settingsResource.ImportState(context.Background(), resource.ImportStateRequest{ID: "haproxy"}, &invalidResp)
+	if !invalidResp.Diagnostics.HasError() {
+		t.Fatalf("expected diagnostic for non-fixed import id")
+	}
+}
+
+func TestHaproxySettingsResourceCreateRequiresImportAndDoesNotWrite(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	settingsResource := &haproxySettingsResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	var resp resource.CreateResponse
+
+	settingsResource.Create(context.Background(), resource.CreateRequest{}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected import-required diagnostic")
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("create made %d REST requests", requests.Load())
+	}
+}
+
+func TestHaproxySettingsResourceUpdatePatchesChangedFieldsOnly(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	var patchPayload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		if r.URL.RequestURI() != "/api/v2/services/haproxy/settings" {
+			t.Fatalf("request uri = %s", r.URL.RequestURI())
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPatch:
+			if err := json.NewDecoder(r.Body).Decode(&patchPayload); err != nil {
+				t.Fatalf("decode patch payload: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":null}`))
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{
+				"code": 200,
+				"status": "ok",
+				"data": {
+					"enable": true,
+					"maxconn": 250,
+					"log-send-hostname": "fw-uat",
+					"advanced": "dW5jaGFuZ2Vk"
+				}
+			}`))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	settingsResource := &haproxySettingsResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxySettingsResourceSchema(t)
+
+	prior := nullHaproxySettingsModel()
+	prior.ID = types.StringValue(haproxySettingsID)
+	prior.Enable = types.BoolValue(false)
+	prior.Maxconn = types.Int64Value(100)
+	prior.LogSendHostname = types.StringValue("")
+	prior.Advanced = types.StringValue("dW5jaGFuZ2Vk")
+
+	plan := prior
+	plan.Enable = types.BoolValue(true)
+	plan.Maxconn = types.Int64Value(250)
+	plan.LogSendHostname = types.StringValue("fw-uat")
+
+	resp := resource.UpdateResponse{
+		State: testResourceState(t, schema, plan),
+	}
+	settingsResource.Update(context.Background(), resource.UpdateRequest{
+		Plan:  testResourcePlan(t, schema, plan),
+		State: testResourceState(t, schema, prior),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"PATCH /api/v2/services/haproxy/settings",
+		"GET /api/v2/services/haproxy/settings",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+
+	if patchPayload["enable"] != true {
+		t.Fatalf("enable patch = %#v", patchPayload["enable"])
+	}
+	if patchPayload["maxconn"] != float64(250) {
+		t.Fatalf("maxconn patch = %#v", patchPayload["maxconn"])
+	}
+	if patchPayload["log-send-hostname"] != "fw-uat" {
+		t.Fatalf("log-send-hostname patch = %#v", patchPayload["log-send-hostname"])
+	}
+	for _, forbidden := range []string{"advanced", "apply", "async", "dns_resolvers", "email_mailers"} {
+		if _, ok := patchPayload[forbidden]; ok {
+			t.Fatalf("patch unexpectedly included %q: %#v", forbidden, patchPayload)
+		}
+	}
+
+	var state haproxySettingsModel
+	diags := resp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if !state.Enable.ValueBool() || state.Maxconn.ValueInt64() != 250 || state.LogSendHostname.ValueString() != "fw-uat" {
+		t.Fatalf("state not refreshed from GET: %#v", state)
+	}
+}
+
+func TestHaproxySettingsResourceDeleteRemovesStateOnly(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	settingsResource := &haproxySettingsResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxySettingsResourceSchema(t)
+	stateModel := nullHaproxySettingsModel()
+	stateModel.ID = types.StringValue(haproxySettingsID)
+
+	resp := resource.DeleteResponse{
+		State: testResourceState(t, schema, stateModel),
+	}
+	settingsResource.Delete(context.Background(), resource.DeleteRequest{
+		State: testResourceState(t, schema, stateModel),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("delete made %d REST requests", requests.Load())
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatalf("state was not removed")
+	}
+}
+
+func TestHaproxySettingsSchemasAreConservative(t *testing.T) {
+	resourceSchema := haproxySettingsResourceSchema(t)
+	if _, ok := resourceSchema.Attributes["dns_resolvers"]; ok {
+		t.Fatalf("resource schema should not manage nested dns_resolvers")
+	}
+	if _, ok := resourceSchema.Attributes["email_mailers"]; ok {
+		t.Fatalf("resource schema should not manage nested email_mailers")
+	}
+	resourceAdvanced, ok := resourceSchema.Attributes["advanced"]
+	if !ok {
+		t.Fatalf("resource schema missing advanced")
+	}
+	if !resourceAdvanced.IsSensitive() {
+		t.Fatalf("resource advanced attribute is not sensitive")
+	}
+
+	dataSourceSchema := haproxySettingsDataSourceSchema(t)
+	dataSourceAdvanced, ok := dataSourceSchema.Attributes["advanced"]
+	if !ok {
+		t.Fatalf("data source schema missing advanced")
+	}
+	if !dataSourceAdvanced.IsSensitive() {
+		t.Fatalf("data source advanced attribute is not sensitive")
+	}
+}
+
+func haproxySettingsResourceSchema(t *testing.T) resourceschema.Schema {
+	t.Helper()
+
+	var resp resource.SchemaResponse
+	(&haproxySettingsResource{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected resource schema diagnostics: %#v", resp.Diagnostics)
+	}
+
+	return resp.Schema
+}
+
+func haproxySettingsDataSourceSchema(t *testing.T) datasourceschema.Schema {
+	t.Helper()
+
+	var resp datasource.SchemaResponse
+	(&haproxySettingsDataSource{}).Schema(context.Background(), datasource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected data source schema diagnostics: %#v", resp.Diagnostics)
+	}
+
+	return resp.Schema
+}
+
+func testResourcePlan(t *testing.T, schema resourceschema.Schema, model haproxySettingsModel) tfsdk.Plan {
+	t.Helper()
+
+	plan := tfsdk.Plan{Schema: schema}
+	diags := plan.Set(context.Background(), model)
+	if diags.HasError() {
+		t.Fatalf("plan set diagnostics: %#v", diags)
+	}
+
+	return plan
+}
+
+func testResourceState(t *testing.T, schema resourceschema.Schema, model haproxySettingsModel) tfsdk.State {
+	t.Helper()
+
+	state := tfsdk.State{Schema: schema}
+	diags := state.Set(context.Background(), model)
+	if diags.HasError() {
+		t.Fatalf("state set diagnostics: %#v", diags)
+	}
+
+	return state
+}
+
+func resourceTypeRegistered(resources []func() resource.Resource, typeName string) bool {
+	for _, constructor := range resources {
+		var metadata resource.MetadataResponse
+		constructor().Metadata(context.Background(), resource.MetadataRequest{}, &metadata)
+		if metadata.TypeName == typeName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func dataSourceTypeRegistered(dataSources []func() datasource.DataSource, typeName string) bool {
+	for _, constructor := range dataSources {
+		var metadata datasource.MetadataResponse
+		constructor().Metadata(context.Background(), datasource.MetadataRequest{}, &metadata)
+		if metadata.TypeName == typeName {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -117,11 +117,15 @@ func (p *haproxyProvider) Configure(ctx context.Context, req provider.ConfigureR
 }
 
 func (p *haproxyProvider) Resources(_ context.Context) []func() resource.Resource {
-	return []func() resource.Resource{}
+	return []func() resource.Resource{
+		newHaproxySettingsResource,
+	}
 }
 
 func (p *haproxyProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{}
+	return []func() datasource.DataSource{
+		newHaproxySettingsDataSource,
+	}
 }
 
 func resolveConfig(config providerConfig) (resolvedConfig, diag.Diagnostics) {


### PR DESCRIPTION
## Summary
- Add pfsense_haproxy_settings data source for GET /services/haproxy/settings.
- Add import-first singleton resource with fixed ID settings, create blocked, update PATCH-only, delete state-only, and no apply/reload behavior.
- Document UAT-pending schema assumptions and add a settings example.

## Tests
- gofmt via make lint
- make lint
- go test ./...
- make test

Closes #6