### PR TITLE
Implement explicit HAProxy apply lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Terraform provider for managing the pfSense HAProxy package through `pfSense-pkg
 ## Status
 
 Bootstrap scaffold is in place. `pfsense_haproxy_settings` is implemented with
-an import-first ownership model. Additional HAProxy resources are tracked
+an import-first ownership model, and `pfsense_haproxy_apply` provides an
+explicit apply/reload lifecycle. Additional HAProxy resources are tracked
 through GitHub issues and milestones.
 
 ## Requirements
@@ -47,9 +48,9 @@ Provider arguments can also be supplied with environment variables:
 
 Prefer API key authentication for automation.
 
-`auto_apply` is intentionally not exposed yet. Apply/reload behavior is reserved
-for the planned `pfsense_haproxy_apply` implementation once HAProxy resource
-semantics are in place.
+`auto_apply` is intentionally not exposed. HAProxy apply/reload behavior is
+modeled explicitly by `pfsense_haproxy_apply`; settings and other durable
+resources do not trigger hidden reloads.
 
 ## HAProxy settings ownership
 
@@ -80,6 +81,50 @@ Import example:
 terraform import pfsense_haproxy_settings.global settings
 ```
 
+## HAProxy apply lifecycle
+
+`data "pfsense_haproxy_apply"` reads `GET /services/haproxy/apply` and exposes:
+
+- `applied`: true when pfSense reports all HAProxy changes are applied.
+- `pending`: true when pfSense reports pending HAProxy changes.
+- `status`: normalized as `done` or `pending`.
+- `status_detail`: human-readable next-step guidance.
+
+`resource "pfsense_haproxy_apply"` is an explicit action resource:
+
+- Create runs `POST /services/haproxy/apply`.
+- Update runs `POST /services/haproxy/apply` only when `triggers` changes.
+- Create/update poll `GET /services/haproxy/apply` until `applied=true`.
+- Polling is bounded by `timeout` and `poll_interval`.
+- Delete removes Terraform state only.
+- Import uses the fixed ID `apply`.
+
+Example:
+
+```hcl
+resource "pfsense_haproxy_apply" "global" {
+  depends_on = [pfsense_haproxy_settings.global]
+
+  triggers = {
+    settings = sha1(jsonencode({
+      enable               = pfsense_haproxy_settings.global.enable
+      maxconn              = pfsense_haproxy_settings.global.maxconn
+      nbthread             = pfsense_haproxy_settings.global.nbthread
+      hard_stop_after      = pfsense_haproxy_settings.global.hard_stop_after
+      sslcompatibilitymode = pfsense_haproxy_settings.global.sslcompatibilitymode
+    }))
+  }
+
+  timeout       = "2m"
+  poll_interval = "2s"
+}
+```
+
+UAT validation is still pending. The implementation assumes the pfREST
+`HAProxyApply` model shape where `GET /services/haproxy/apply` returns an
+`applied` boolean, and `POST /services/haproxy/apply` starts HAProxy
+configuration application.
+
 ## Development
 
 ```bash
@@ -92,6 +137,7 @@ make testacc
 
 ## Resources
 
+- `pfsense_haproxy_apply`
 - `pfsense_haproxy_settings`
 
 ## Planned resources
@@ -104,7 +150,6 @@ make testacc
 - `pfsense_haproxy_frontend_action`
 - `pfsense_haproxy_frontend_certificate`
 - `pfsense_haproxy_file`
-- `pfsense_haproxy_apply`
 
 ## Example ingress contract
 

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -76,3 +76,10 @@ For M2-01, `pfsense_haproxy_settings` uses the upstream
 Terraform manages only scalar fields, treats `advanced` as sensitive, and does
 not manage nested DNS resolver or email mailer children until UAT confirms their
 ownership model.
+
+For M2-02, `pfsense_haproxy_apply` uses the upstream `HAProxyApply.inc` model as
+a conservative implementation reference: `GET /services/haproxy/apply` is
+assumed to return an `applied` boolean, and `POST /services/haproxy/apply` is
+assumed to start HAProxy configuration application. The Terraform resource keeps
+apply explicit with user-controlled `triggers`; settings and other durable
+resources must not auto-apply pending changes.

--- a/docs/schema/resource-schema-decisions.md
+++ b/docs/schema/resource-schema-decisions.md
@@ -26,6 +26,9 @@ Primary references:
 - HAProxy write endpoints do not apply pending service changes immediately in
   the public OpenAPI metadata. Use an explicit apply workflow instead of hidden
   automatic reloads.
+- Model HAProxy apply as an explicit action resource and read-only status data
+  source. Do not add auto-apply flags to settings or durable resources unless a
+  later issue intentionally changes that contract.
 - Mark actual secret-bearing attributes as sensitive when implemented. Public
   schema names include `stats_password`, `HAProxyFile.content`, certificate
   references, and custom/advanced HAProxy text fields that may carry private
@@ -50,7 +53,7 @@ Primary references:
 | `pfsense_haproxy_file` | HAProxyFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/file`; `GET /files` | Create requires `name`, `content`. Patch requires `id`. | Defer until routes require managed HAProxy files. `content` must be sensitive in Terraform state and excluded from schema fixtures. |
 | `pfsense_haproxy_settings_dns_resolver` | HAProxyDNSResolver | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/settings/dns_resolver` | Create requires `name`, `server`. Patch requires `id`. | Model as settings child only if needed. Pending UAT confirmation of nesting and IDs. |
 | `pfsense_haproxy_settings_email_mailer` | HAProxyEmailMailer | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/settings/email_mailer` | Create requires `name`, `mailserver`. Patch requires `id`. | Model as settings child only if needed. Pending UAT confirmation of nesting and IDs. |
-| `pfsense_haproxy_apply` | HAProxyApply | `GET/POST /api/v2/services/haproxy/apply` | `GET` reports `applied`; `POST` applies pending changes. | Not a durable config resource. Implement as an explicit apply/action workflow after CRUD resources exist. |
+| `pfsense_haproxy_apply` | HAProxyApply | `GET/POST /api/v2/services/haproxy/apply` | `GET` reports `applied`; `POST` applies pending changes. | Implemented in M2-02 as a status data source and singleton action resource with fixed ID `apply`, user-controlled `triggers`, POST guarded by the shared client write guard, bounded polling, state-only delete, and no hidden apply behavior in other resources. |
 
 ## Pending UAT Questions
 
@@ -62,6 +65,10 @@ Primary references:
 - Confirm no endpoint-side `apply` default is triggered by
   `PATCH /api/v2/services/haproxy/settings` when no apply control parameter is
   supplied.
+- Confirm `GET /api/v2/services/haproxy/apply` returns a boolean `applied`
+  field on UAT and whether any extra error/status fields should be exposed.
+- Confirm `POST /api/v2/services/haproxy/apply` returns quickly enough for the
+  current poll defaults or whether UAT needs different timeout guidance.
 - Exact response envelope for create/update/delete, including where object IDs are
   returned.
 - Whether UAT uses numeric IDs, string IDs, or mixed IDs for every HAProxy model.

--- a/examples/haproxy_settings.tf
+++ b/examples/haproxy_settings.tf
@@ -1,5 +1,7 @@
 data "pfsense_haproxy_settings" "current" {}
 
+data "pfsense_haproxy_apply" "status" {}
+
 # Import before managing:
 # terraform import pfsense_haproxy_settings.global settings
 #
@@ -16,4 +18,30 @@ resource "pfsense_haproxy_settings" "global" {
   resolver_retries     = 3
   sslcompatibilitymode = "auto"
   ssldefaultdhparam    = 2048
+}
+
+# Explicit apply after settings changes. There is intentionally no hidden
+# auto-apply in pfsense_haproxy_settings or other durable HAProxy resources.
+#
+# UAT note: this assumes GET /services/haproxy/apply reports an "applied"
+# boolean and POST /services/haproxy/apply starts HAProxy config application.
+resource "pfsense_haproxy_apply" "global" {
+  depends_on = [pfsense_haproxy_settings.global]
+
+  triggers = {
+    settings = sha1(jsonencode({
+      enable               = pfsense_haproxy_settings.global.enable
+      maxconn              = pfsense_haproxy_settings.global.maxconn
+      nbthread             = pfsense_haproxy_settings.global.nbthread
+      hard_stop_after      = pfsense_haproxy_settings.global.hard_stop_after
+      logfacility          = pfsense_haproxy_settings.global.logfacility
+      loglevel             = pfsense_haproxy_settings.global.loglevel
+      resolver_retries     = pfsense_haproxy_settings.global.resolver_retries
+      sslcompatibilitymode = pfsense_haproxy_settings.global.sslcompatibilitymode
+      ssldefaultdhparam    = pfsense_haproxy_settings.global.ssldefaultdhparam
+    }))
+  }
+
+  timeout       = "2m"
+  poll_interval = "2s"
 }

--- a/internal/provider/haproxy_apply.go
+++ b/internal/provider/haproxy_apply.go
@@ -342,7 +342,7 @@ func readHaproxyApplyStatus(ctx context.Context, client *pfsense.Client) (haprox
 }
 
 func applyAndWaitForHaproxy(ctx context.Context, client *pfsense.Client, timeout time.Duration, pollInterval time.Duration) (haproxyApplyStatus, error) {
-	if err := client.Post(ctx, haproxyApplyPath, map[string]any{}, nil); err != nil {
+	if err := client.Post(ctx, haproxyApplyPath, map[string]any{"async": true}, nil); err != nil {
 		return haproxyApplyStatus{}, fmt.Errorf("start HAProxy apply with POST %s: %w", haproxyApplyPath, err)
 	}
 

--- a/internal/provider/haproxy_apply.go
+++ b/internal/provider/haproxy_apply.go
@@ -1,0 +1,533 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	haproxyApplyID                  = "apply"
+	haproxyApplyPath                = "/services/haproxy/apply"
+	defaultHaproxyApplyTimeout      = 2 * time.Minute
+	defaultHaproxyApplyPollInterval = 2 * time.Second
+)
+
+var (
+	_ datasource.DataSource              = (*haproxyApplyDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*haproxyApplyDataSource)(nil)
+	_ resource.Resource                  = (*haproxyApplyResource)(nil)
+	_ resource.ResourceWithConfigure     = (*haproxyApplyResource)(nil)
+	_ resource.ResourceWithImportState   = (*haproxyApplyResource)(nil)
+)
+
+type haproxyApplyDataSource struct {
+	client *pfsense.Client
+}
+
+type haproxyApplyResource struct {
+	client *pfsense.Client
+}
+
+type haproxyApplyStatusModel struct {
+	ID           types.String `tfsdk:"id"`
+	Applied      types.Bool   `tfsdk:"applied"`
+	Pending      types.Bool   `tfsdk:"pending"`
+	Status       types.String `tfsdk:"status"`
+	StatusDetail types.String `tfsdk:"status_detail"`
+}
+
+type haproxyApplyResourceModel struct {
+	ID           types.String `tfsdk:"id"`
+	Triggers     types.Map    `tfsdk:"triggers"`
+	Timeout      types.String `tfsdk:"timeout"`
+	PollInterval types.String `tfsdk:"poll_interval"`
+	Applied      types.Bool   `tfsdk:"applied"`
+	Pending      types.Bool   `tfsdk:"pending"`
+	Status       types.String `tfsdk:"status"`
+	StatusDetail types.String `tfsdk:"status_detail"`
+}
+
+type haproxyApplyStatus struct {
+	Applied bool
+}
+
+type haproxyApplyPendingError struct {
+	Timeout  time.Duration
+	Attempts int
+}
+
+func (e *haproxyApplyPendingError) Error() string {
+	return fmt.Sprintf(
+		"HAProxy apply remained pending after %s (%d status checks); pfSense still reports applied=false, which usually means /var/run/haproxy.conf.dirty exists. Inspect HAProxy configuration validation output and pfSense REST API or HAProxy logs, then retry pfsense_haproxy_apply.",
+		e.Timeout,
+		e.Attempts,
+	)
+}
+
+func newHaproxyApplyDataSource() datasource.DataSource {
+	return &haproxyApplyDataSource{}
+}
+
+func newHaproxyApplyResource() resource.Resource {
+	return &haproxyApplyResource{}
+}
+
+func (d *haproxyApplyDataSource) Metadata(_ context.Context, _ datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "pfsense_haproxy_apply"
+}
+
+func (d *haproxyApplyDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = datasourceschema.Schema{
+		Description: "Reads the current pfSense HAProxy apply status from GET /services/haproxy/apply without triggering an apply.",
+		Attributes:  haproxyApplyStatusDataSourceSchemaAttributes(),
+	}
+}
+
+func (d *haproxyApplyDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*pfsense.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected data source configure type", fmt.Sprintf("Expected *pfsense.Client, got %T.", req.ProviderData))
+		return
+	}
+
+	d.client = client
+}
+
+func (d *haproxyApplyDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if d.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before reading pfsense_haproxy_apply.")
+		return
+	}
+
+	status, err := readHaproxyApplyStatus(ctx, d.client)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy apply status failed", applyStatusErrorDetail(err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, haproxyApplyStatusModelFromStatus(status))...)
+}
+
+func (r *haproxyApplyResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "pfsense_haproxy_apply"
+}
+
+func (r *haproxyApplyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resourceschema.Schema{
+		Description: "Explicitly applies pending pfSense HAProxy package changes with POST /services/haproxy/apply and bounded polling against GET /services/haproxy/apply. Other HAProxy resources do not trigger hidden apply/reload operations.",
+		Attributes:  haproxyApplyResourceSchemaAttributes(),
+	}
+}
+
+func (r *haproxyApplyResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*pfsense.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected resource configure type", fmt.Sprintf("Expected *pfsense.Client, got %T.", req.ProviderData))
+		return
+	}
+
+	r.client = client
+}
+
+func (r *haproxyApplyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before creating pfsense_haproxy_apply.")
+		return
+	}
+
+	var plan haproxyApplyResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !validHaproxyApplyID(plan.ID, &resp.Diagnostics) {
+		return
+	}
+
+	timeout, pollInterval, diags := haproxyApplyPollingConfig(plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	status, err := applyAndWaitForHaproxy(ctx, r.client, timeout, pollInterval)
+	if err != nil {
+		resp.Diagnostics.AddError("Apply HAProxy changes failed", applyOperationErrorDetail(err))
+		return
+	}
+
+	tflog.Info(ctx, "HAProxy apply completed", map[string]any{"status": "done"})
+	resp.Diagnostics.Append(resp.State.Set(ctx, haproxyApplyResourceModelFromStatus(plan, status, timeout, pollInterval))...)
+}
+
+func (r *haproxyApplyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before reading pfsense_haproxy_apply.")
+		return
+	}
+
+	var state haproxyApplyResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !validHaproxyApplyID(state.ID, &resp.Diagnostics) {
+		return
+	}
+
+	timeout, pollInterval, diags := haproxyApplyPollingConfig(state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	status, err := readHaproxyApplyStatus(ctx, r.client)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy apply status failed", applyStatusErrorDetail(err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, haproxyApplyResourceModelFromStatus(state, status, timeout, pollInterval))...)
+}
+
+func (r *haproxyApplyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before updating pfsense_haproxy_apply.")
+		return
+	}
+
+	var plan, prior haproxyApplyResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !validHaproxyApplyID(plan.ID, &resp.Diagnostics) || !validHaproxyApplyID(prior.ID, &resp.Diagnostics) {
+		return
+	}
+
+	timeout, pollInterval, diags := haproxyApplyPollingConfig(plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var status haproxyApplyStatus
+	var err error
+	if haproxyApplyTriggersChanged(plan.Triggers, prior.Triggers) {
+		status, err = applyAndWaitForHaproxy(ctx, r.client, timeout, pollInterval)
+		if err != nil {
+			resp.Diagnostics.AddError("Apply HAProxy changes failed", applyOperationErrorDetail(err))
+			return
+		}
+		tflog.Info(ctx, "HAProxy apply completed", map[string]any{"status": "done"})
+	} else {
+		status, err = readHaproxyApplyStatus(ctx, r.client)
+		if err != nil {
+			resp.Diagnostics.AddError("Read HAProxy apply status failed", applyStatusErrorDetail(err))
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, haproxyApplyResourceModelFromStatus(plan, status, timeout, pollInterval))...)
+}
+
+func (r *haproxyApplyResource) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *haproxyApplyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	if req.ID != haproxyApplyID {
+		resp.Diagnostics.AddError("Invalid HAProxy apply import ID", fmt.Sprintf("Import pfsense_haproxy_apply with the fixed ID %q.", haproxyApplyID))
+		return
+	}
+
+	model := nullHaproxyApplyResourceModel()
+	model.ID = types.StringValue(haproxyApplyID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func haproxyApplyStatusDataSourceSchemaAttributes() map[string]datasourceschema.Attribute {
+	return map[string]datasourceschema.Attribute{
+		"id": datasourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Fixed singleton ID for the HAProxy apply endpoint.",
+		},
+		"applied": datasourceschema.BoolAttribute{
+			Computed:    true,
+			Description: "True when pfSense reports all HAProxy configuration changes have been applied.",
+		},
+		"pending": datasourceschema.BoolAttribute{
+			Computed:    true,
+			Description: "True when pfSense reports HAProxy configuration changes are still pending.",
+		},
+		"status": datasourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Normalized apply status: done when applied is true, pending when applied is false.",
+		},
+		"status_detail": datasourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Human-readable status detail with next-step guidance for pending or completed apply state.",
+		},
+	}
+}
+
+func haproxyApplyResourceSchemaAttributes() map[string]resourceschema.Attribute {
+	return map[string]resourceschema.Attribute{
+		"id": resourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Fixed singleton ID for the HAProxy apply endpoint. Import must use \"apply\".",
+		},
+		"triggers": resourceschema.MapAttribute{
+			Optional:    true,
+			ElementType: types.StringType,
+			Description: "User-controlled string values that cause a new POST /services/haproxy/apply during resource update when changed. Reference managed HAProxy resources here to make apply explicit and repeatable.",
+		},
+		"timeout": resourceschema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Maximum time to poll GET /services/haproxy/apply after POST before failing while pending. Defaults to 2m.",
+		},
+		"poll_interval": resourceschema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Interval between HAProxy apply status checks while pending. Defaults to 2s.",
+		},
+		"applied": resourceschema.BoolAttribute{
+			Computed:    true,
+			Description: "True when pfSense reports all HAProxy configuration changes have been applied.",
+		},
+		"pending": resourceschema.BoolAttribute{
+			Computed:    true,
+			Description: "True when pfSense reports HAProxy configuration changes are still pending.",
+		},
+		"status": resourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Normalized apply status: done when applied is true, pending when applied is false.",
+		},
+		"status_detail": resourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Human-readable status detail with next-step guidance for pending or completed apply state.",
+		},
+	}
+}
+
+func readHaproxyApplyStatus(ctx context.Context, client *pfsense.Client) (haproxyApplyStatus, error) {
+	var payload map[string]any
+	if err := client.Get(ctx, haproxyApplyPath, &payload); err != nil {
+		return haproxyApplyStatus{}, err
+	}
+
+	return haproxyApplyStatusFromAPI(payload)
+}
+
+func applyAndWaitForHaproxy(ctx context.Context, client *pfsense.Client, timeout time.Duration, pollInterval time.Duration) (haproxyApplyStatus, error) {
+	if err := client.Post(ctx, haproxyApplyPath, map[string]any{}, nil); err != nil {
+		return haproxyApplyStatus{}, fmt.Errorf("start HAProxy apply with POST %s: %w", haproxyApplyPath, err)
+	}
+
+	return pollHaproxyApplyStatus(ctx, client, timeout, pollInterval)
+}
+
+func pollHaproxyApplyStatus(ctx context.Context, client *pfsense.Client, timeout time.Duration, pollInterval time.Duration) (haproxyApplyStatus, error) {
+	deadline := time.Now().Add(timeout)
+	attempts := 0
+
+	for {
+		status, err := readHaproxyApplyStatus(ctx, client)
+		attempts++
+		if err != nil {
+			return haproxyApplyStatus{}, fmt.Errorf("read HAProxy apply status with GET %s: %w", haproxyApplyPath, err)
+		}
+		if status.Applied {
+			return status, nil
+		}
+		if !time.Now().Before(deadline) {
+			return status, &haproxyApplyPendingError{
+				Timeout:  timeout,
+				Attempts: attempts,
+			}
+		}
+
+		sleepFor := pollInterval
+		if remaining := time.Until(deadline); remaining < sleepFor {
+			sleepFor = remaining
+		}
+
+		timer := time.NewTimer(sleepFor)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return haproxyApplyStatus{}, fmt.Errorf("HAProxy apply polling canceled: %w", ctx.Err())
+		}
+	}
+}
+
+func haproxyApplyStatusFromAPI(payload map[string]any) (haproxyApplyStatus, error) {
+	applied, err := apiBoolWithLabel(payload, "HAProxy apply", "applied")
+	if err != nil {
+		return haproxyApplyStatus{}, err
+	}
+	if applied.IsNull() || applied.IsUnknown() {
+		return haproxyApplyStatus{}, fmt.Errorf("HAProxy apply response did not include required boolean field %q; confirm the live UAT /services/haproxy/apply schema before relying on apply automation", "applied")
+	}
+
+	return haproxyApplyStatus{Applied: applied.ValueBool()}, nil
+}
+
+func haproxyApplyStatusModelFromStatus(status haproxyApplyStatus) haproxyApplyStatusModel {
+	statusText, detail := haproxyApplyStatusText(status)
+
+	return haproxyApplyStatusModel{
+		ID:           types.StringValue(haproxyApplyID),
+		Applied:      types.BoolValue(status.Applied),
+		Pending:      types.BoolValue(!status.Applied),
+		Status:       types.StringValue(statusText),
+		StatusDetail: types.StringValue(detail),
+	}
+}
+
+func haproxyApplyResourceModelFromStatus(config haproxyApplyResourceModel, status haproxyApplyStatus, timeout time.Duration, pollInterval time.Duration) haproxyApplyResourceModel {
+	statusText, detail := haproxyApplyStatusText(status)
+
+	return haproxyApplyResourceModel{
+		ID:           types.StringValue(haproxyApplyID),
+		Triggers:     normalizedHaproxyApplyTriggers(config.Triggers),
+		Timeout:      normalizedDurationAttribute(config.Timeout, timeout),
+		PollInterval: normalizedDurationAttribute(config.PollInterval, pollInterval),
+		Applied:      types.BoolValue(status.Applied),
+		Pending:      types.BoolValue(!status.Applied),
+		Status:       types.StringValue(statusText),
+		StatusDetail: types.StringValue(detail),
+	}
+}
+
+func haproxyApplyStatusText(status haproxyApplyStatus) (string, string) {
+	if status.Applied {
+		return "done", "pfSense reports all HAProxy changes are applied (applied=true)."
+	}
+
+	return "pending", "pfSense reports HAProxy changes are pending (applied=false). Trigger pfsense_haproxy_apply or inspect HAProxy validation output if the status remains pending."
+}
+
+func nullHaproxyApplyResourceModel() haproxyApplyResourceModel {
+	return haproxyApplyResourceModel{
+		ID:           types.StringNull(),
+		Triggers:     types.MapNull(types.StringType),
+		Timeout:      types.StringNull(),
+		PollInterval: types.StringNull(),
+		Applied:      types.BoolNull(),
+		Pending:      types.BoolNull(),
+		Status:       types.StringNull(),
+		StatusDetail: types.StringNull(),
+	}
+}
+
+func haproxyApplyPollingConfig(model haproxyApplyResourceModel) (time.Duration, time.Duration, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	timeout, d := durationAttribute(model.Timeout, "timeout", defaultHaproxyApplyTimeout)
+	diags.Append(d...)
+	pollInterval, d := durationAttribute(model.PollInterval, "poll_interval", defaultHaproxyApplyPollInterval)
+	diags.Append(d...)
+	if timeout > 0 && pollInterval > timeout {
+		diags.AddError("Invalid HAProxy apply polling configuration", "poll_interval must be less than or equal to timeout.")
+	}
+
+	return timeout, pollInterval, diags
+}
+
+func durationAttribute(value types.String, attrName string, fallback time.Duration) (time.Duration, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if value.IsNull() || value.IsUnknown() {
+		return fallback, diags
+	}
+
+	raw := value.ValueString()
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		diags.AddError("Invalid HAProxy apply duration", fmt.Sprintf("%s=%q is not a valid duration.", attrName, raw))
+		return fallback, diags
+	}
+	if parsed <= 0 {
+		diags.AddError("Invalid HAProxy apply duration", fmt.Sprintf("%s must be greater than zero.", attrName))
+		return fallback, diags
+	}
+
+	return parsed, diags
+}
+
+func normalizedDurationAttribute(value types.String, parsed time.Duration) types.String {
+	if value.IsNull() || value.IsUnknown() {
+		return types.StringValue(parsed.String())
+	}
+	return value
+}
+
+func validHaproxyApplyID(id types.String, diags *diag.Diagnostics) bool {
+	if id.IsNull() || id.IsUnknown() {
+		return true
+	}
+	if id.ValueString() == haproxyApplyID {
+		return true
+	}
+
+	diags.AddError("Invalid HAProxy apply ID", fmt.Sprintf("Expected ID %q, got %q.", haproxyApplyID, id.ValueString()))
+	return false
+}
+
+func haproxyApplyTriggersChanged(plan types.Map, prior types.Map) bool {
+	return !normalizedHaproxyApplyTriggers(plan).Equal(normalizedHaproxyApplyTriggers(prior))
+}
+
+func normalizedHaproxyApplyTriggers(value types.Map) types.Map {
+	if value.IsNull() || value.IsUnknown() {
+		return types.MapNull(types.StringType)
+	}
+
+	elements := make(map[string]attr.Value, len(value.Elements()))
+	for key, element := range value.Elements() {
+		elements[key] = element
+	}
+
+	return types.MapValueMust(types.StringType, elements)
+}
+
+func applyStatusErrorDetail(err error) string {
+	return fmt.Sprintf("%s. Confirm GET %s is available on the UAT firewall, the HAProxy package is installed, and the REST API credential has HAProxy apply privileges.", err.Error(), haproxyApplyPath)
+}
+
+func applyOperationErrorDetail(err error) string {
+	var pendingErr *haproxyApplyPendingError
+	if errors.As(err, &pendingErr) {
+		return fmt.Sprintf("%s. POST %s was sent, but GET %s did not report applied=true before timeout. Inspect HAProxy configuration validation output and check pfSense REST API or HAProxy logs before retrying.", err.Error(), haproxyApplyPath, haproxyApplyPath)
+	}
+
+	return fmt.Sprintf("%s. Confirm POST %s is available on the UAT firewall, inspect HAProxy configuration validation output, and check pfSense REST API or HAProxy logs before retrying.", err.Error(), haproxyApplyPath)
+}

--- a/internal/provider/haproxy_apply_test.go
+++ b/internal/provider/haproxy_apply_test.go
@@ -106,7 +106,7 @@ func TestHaproxyApplyResourceCreatePostsAndPollsUntilDone(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Fatalf("decode POST payload: %v", err)
 			}
-			if len(payload) != 0 {
+			if payload["async"] != true || len(payload) != 1 {
 				t.Fatalf("POST payload = %#v", payload)
 			}
 			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"applied":false}}`))

--- a/internal/provider/haproxy_apply_test.go
+++ b/internal/provider/haproxy_apply_test.go
@@ -1,0 +1,432 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestHaproxyApplyDataSourceReadPendingUsesGET(t *testing.T) {
+	t.Parallel()
+
+	var requests []string
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if r.URL.RequestURI() != "/api/v2/services/haproxy/apply" {
+			t.Fatalf("request uri = %s", r.URL.RequestURI())
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"applied":false}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	applyDataSource := &haproxyApplyDataSource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	resp := datasource.ReadResponse{
+		State: tfsdk.State{Schema: haproxyApplyDataSourceSchema(t)},
+	}
+
+	applyDataSource.Read(context.Background(), datasource.ReadRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	if want := []string{"GET /api/v2/services/haproxy/apply"}; !reflect.DeepEqual(gotRequests, want) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, want)
+	}
+
+	var state haproxyApplyStatusModel
+	diags := resp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.ID.ValueString() != haproxyApplyID {
+		t.Fatalf("id = %q", state.ID.ValueString())
+	}
+	if state.Applied.ValueBool() {
+		t.Fatalf("applied = true")
+	}
+	if !state.Pending.ValueBool() {
+		t.Fatalf("pending = false")
+	}
+	if state.Status.ValueString() != "pending" {
+		t.Fatalf("status = %q", state.Status.ValueString())
+	}
+	if !strings.Contains(state.StatusDetail.ValueString(), "applied=false") {
+		t.Fatalf("status detail = %q", state.StatusDetail.ValueString())
+	}
+}
+
+func TestHaproxyApplyResourceCreatePostsAndPollsUntilDone(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	gets := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		if r.URL.RequestURI() != "/api/v2/services/haproxy/apply" {
+			t.Fatalf("request uri = %s", r.URL.RequestURI())
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPost:
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode POST payload: %v", err)
+			}
+			if len(payload) != 0 {
+				t.Fatalf("POST payload = %#v", payload)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"applied":false}}`))
+		case http.MethodGet:
+			gets++
+			if gets == 1 {
+				_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"applied":false}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"applied":true}}`))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	applyResource := &haproxyApplyResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyApplyResourceSchema(t)
+	plan := nullHaproxyApplyResourceModel()
+	plan.Triggers = testStringMap(t, map[string]string{"settings": "v1"})
+	plan.Timeout = types.StringValue("1s")
+	plan.PollInterval = types.StringValue("1ns")
+
+	resp := resource.CreateResponse{
+		State: testResourceState(t, schema, plan),
+	}
+	applyResource.Create(context.Background(), resource.CreateRequest{
+		Plan: testResourcePlan(t, schema, plan),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"POST /api/v2/services/haproxy/apply",
+		"GET /api/v2/services/haproxy/apply",
+		"GET /api/v2/services/haproxy/apply",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+
+	var state haproxyApplyResourceModel
+	diags := resp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if !state.Applied.ValueBool() || state.Pending.ValueBool() || state.Status.ValueString() != "done" {
+		t.Fatalf("state not marked done: %#v", state)
+	}
+	if state.Timeout.ValueString() != "1s" || state.PollInterval.ValueString() != "1ns" {
+		t.Fatalf("polling config not preserved: timeout=%q poll_interval=%q", state.Timeout.ValueString(), state.PollInterval.ValueString())
+	}
+	if state.Triggers.Elements()["settings"].(types.String).ValueString() != "v1" {
+		t.Fatalf("triggers not preserved: %#v", state.Triggers.Elements())
+	}
+}
+
+func TestHaproxyApplyResourceCreateTimesOutWhenPending(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RequestURI() != "/api/v2/services/haproxy/apply" {
+			t.Fatalf("request uri = %s", r.URL.RequestURI())
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPost:
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"applied":false}}`))
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"applied":false}}`))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	applyResource := &haproxyApplyResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyApplyResourceSchema(t)
+	plan := nullHaproxyApplyResourceModel()
+	plan.Timeout = types.StringValue("1ns")
+	plan.PollInterval = types.StringValue("1ns")
+
+	var resp resource.CreateResponse
+	resp.State = testResourceState(t, schema, plan)
+	applyResource.Create(context.Background(), resource.CreateRequest{
+		Plan: testResourcePlan(t, schema, plan),
+	}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected pending timeout diagnostic")
+	}
+
+	got := diagnosticsText(resp.Diagnostics)
+	for _, want := range []string{"pending", "/var/run/haproxy.conf.dirty", "POST /services/haproxy/apply", "HAProxy logs"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("diagnostics %q do not contain %q", got, want)
+		}
+	}
+}
+
+func TestHaproxyApplyResourceCreateReportsPostError(t *testing.T) {
+	t.Parallel()
+
+	var requests []string
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		if r.URL.RequestURI() != "/api/v2/services/haproxy/apply" {
+			t.Fatalf("request uri = %s", r.URL.RequestURI())
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{
+			"code": 422,
+			"status": "error",
+			"response_id": "resp-haproxy-apply",
+			"message": "invalid HAProxy configuration"
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	applyResource := &haproxyApplyResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyApplyResourceSchema(t)
+	plan := nullHaproxyApplyResourceModel()
+	plan.Timeout = types.StringValue("1s")
+	plan.PollInterval = types.StringValue("1ms")
+
+	var resp resource.CreateResponse
+	resp.State = testResourceState(t, schema, plan)
+	applyResource.Create(context.Background(), resource.CreateRequest{
+		Plan: testResourcePlan(t, schema, plan),
+	}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected POST error diagnostic")
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	if want := []string{"POST /api/v2/services/haproxy/apply"}; !reflect.DeepEqual(gotRequests, want) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, want)
+	}
+
+	got := diagnosticsText(resp.Diagnostics)
+	for _, want := range []string{"422 Unprocessable Entity", "invalid HAProxy configuration", "response_id: resp-haproxy-apply", "POST /services/haproxy/apply"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("diagnostics %q do not contain %q", got, want)
+		}
+	}
+}
+
+func TestHaproxyApplyResourceUpdatePostsOnlyWhenTriggersChange(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		if r.URL.RequestURI() != "/api/v2/services/haproxy/apply" {
+			t.Fatalf("request uri = %s", r.URL.RequestURI())
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPost:
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"applied":true}}`))
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"applied":true}}`))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	applyResource := &haproxyApplyResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyApplyResourceSchema(t)
+
+	prior := nullHaproxyApplyResourceModel()
+	prior.ID = types.StringValue(haproxyApplyID)
+	prior.Triggers = testStringMap(t, map[string]string{"settings": "v1"})
+	prior.Timeout = types.StringValue("1s")
+	prior.PollInterval = types.StringValue("1ms")
+	prior.Applied = types.BoolValue(true)
+	prior.Pending = types.BoolValue(false)
+	prior.Status = types.StringValue("done")
+	prior.StatusDetail = types.StringValue("pfSense reports all HAProxy changes are applied (applied=true).")
+
+	sameTriggerPlan := prior
+	sameTriggerPlan.Timeout = types.StringValue("2s")
+
+	noPostResp := resource.UpdateResponse{
+		State: testResourceState(t, schema, prior),
+	}
+	applyResource.Update(context.Background(), resource.UpdateRequest{
+		Plan:  testResourcePlan(t, schema, sameTriggerPlan),
+		State: testResourceState(t, schema, prior),
+	}, &noPostResp)
+	if noPostResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics for same trigger update: %#v", noPostResp.Diagnostics)
+	}
+
+	changedTriggerPlan := sameTriggerPlan
+	changedTriggerPlan.Triggers = testStringMap(t, map[string]string{"settings": "v2"})
+	changedResp := resource.UpdateResponse{
+		State: testResourceState(t, schema, sameTriggerPlan),
+	}
+	applyResource.Update(context.Background(), resource.UpdateRequest{
+		Plan:  testResourcePlan(t, schema, changedTriggerPlan),
+		State: testResourceState(t, schema, sameTriggerPlan),
+	}, &changedResp)
+	if changedResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics for changed trigger update: %#v", changedResp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/apply",
+		"POST /api/v2/services/haproxy/apply",
+		"GET /api/v2/services/haproxy/apply",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+}
+
+func TestHaproxyApplyResourceImportRequiresFixedID(t *testing.T) {
+	t.Parallel()
+
+	applyResource := &haproxyApplyResource{}
+	schema := haproxyApplyResourceSchema(t)
+
+	validResp := resource.ImportStateResponse{
+		State: tfsdk.State{Schema: schema},
+	}
+	applyResource.ImportState(context.Background(), resource.ImportStateRequest{ID: haproxyApplyID}, &validResp)
+	if validResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", validResp.Diagnostics)
+	}
+
+	var state haproxyApplyResourceModel
+	diags := validResp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.ID.ValueString() != haproxyApplyID {
+		t.Fatalf("imported id = %q", state.ID.ValueString())
+	}
+
+	invalidResp := resource.ImportStateResponse{
+		State: tfsdk.State{Schema: schema},
+	}
+	applyResource.ImportState(context.Background(), resource.ImportStateRequest{ID: "haproxy"}, &invalidResp)
+	if !invalidResp.Diagnostics.HasError() {
+		t.Fatalf("expected diagnostic for non-fixed import id")
+	}
+}
+
+func haproxyApplyResourceSchema(t *testing.T) resourceschema.Schema {
+	t.Helper()
+
+	var resp resource.SchemaResponse
+	(&haproxyApplyResource{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected resource schema diagnostics: %#v", resp.Diagnostics)
+	}
+
+	return resp.Schema
+}
+
+func haproxyApplyDataSourceSchema(t *testing.T) datasourceschema.Schema {
+	t.Helper()
+
+	var resp datasource.SchemaResponse
+	(&haproxyApplyDataSource{}).Schema(context.Background(), datasource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected data source schema diagnostics: %#v", resp.Diagnostics)
+	}
+
+	return resp.Schema
+}
+
+func testStringMap(t *testing.T, values map[string]string) types.Map {
+	t.Helper()
+
+	elements := make(map[string]attr.Value, len(values))
+	for key, value := range values {
+		elements[key] = types.StringValue(value)
+	}
+
+	return types.MapValueMust(types.StringType, elements)
+}
+
+func diagnosticsText(diags diag.Diagnostics) string {
+	parts := make([]string, 0, len(diags)*2)
+	for _, d := range diags {
+		parts = append(parts, d.Summary(), d.Detail())
+	}
+	return strings.Join(parts, "\n")
+}

--- a/internal/provider/haproxy_settings.go
+++ b/internal/provider/haproxy_settings.go
@@ -528,6 +528,10 @@ func terraformValueToJSON(kind settingsAttributeKind, value attr.Value) any {
 }
 
 func apiBool(payload map[string]any, names ...string) (types.Bool, error) {
+	return apiBoolWithLabel(payload, "HAProxy settings", names...)
+}
+
+func apiBoolWithLabel(payload map[string]any, label string, names ...string) (types.Bool, error) {
 	value, name, ok := apiValue(payload, names...)
 	if !ok || value == nil {
 		return types.BoolNull(), nil
@@ -543,7 +547,7 @@ func apiBool(payload map[string]any, names ...string) (types.Bool, error) {
 		case "0", "false", "no", "off", "":
 			return types.BoolValue(false), nil
 		default:
-			return types.BoolNull(), fmt.Errorf("HAProxy settings field %q is %q, not a boolean", name, typed)
+			return types.BoolNull(), fmt.Errorf("%s field %q is %q, not a boolean", label, name, typed)
 		}
 	case float64:
 		if typed == 0 {
@@ -552,11 +556,11 @@ func apiBool(payload map[string]any, names ...string) (types.Bool, error) {
 		if typed == 1 {
 			return types.BoolValue(true), nil
 		}
-		return types.BoolNull(), fmt.Errorf("HAProxy settings field %q is %v, not a boolean", name, typed)
+		return types.BoolNull(), fmt.Errorf("%s field %q is %v, not a boolean", label, name, typed)
 	case json.Number:
 		intValue, err := typed.Int64()
 		if err != nil {
-			return types.BoolNull(), fmt.Errorf("HAProxy settings field %q is %q, not a boolean: %w", name, typed.String(), err)
+			return types.BoolNull(), fmt.Errorf("%s field %q is %q, not a boolean: %w", label, name, typed.String(), err)
 		}
 		if intValue == 0 {
 			return types.BoolValue(false), nil
@@ -564,9 +568,9 @@ func apiBool(payload map[string]any, names ...string) (types.Bool, error) {
 		if intValue == 1 {
 			return types.BoolValue(true), nil
 		}
-		return types.BoolNull(), fmt.Errorf("HAProxy settings field %q is %q, not a boolean", name, typed.String())
+		return types.BoolNull(), fmt.Errorf("%s field %q is %q, not a boolean", label, name, typed.String())
 	default:
-		return types.BoolNull(), fmt.Errorf("HAProxy settings field %q has unsupported boolean type %T", name, value)
+		return types.BoolNull(), fmt.Errorf("%s field %q has unsupported boolean type %T", label, name, value)
 	}
 }
 

--- a/internal/provider/haproxy_settings_test.go
+++ b/internal/provider/haproxy_settings_test.go
@@ -23,11 +23,17 @@ func TestProviderRegistersHaproxySettings(t *testing.T) {
 	provider := &haproxyProvider{}
 
 	resources := provider.Resources(context.Background())
+	if !resourceTypeRegistered(resources, "pfsense_haproxy_apply") {
+		t.Fatalf("pfsense_haproxy_apply resource was not registered")
+	}
 	if !resourceTypeRegistered(resources, "pfsense_haproxy_settings") {
 		t.Fatalf("pfsense_haproxy_settings resource was not registered")
 	}
 
 	dataSources := provider.DataSources(context.Background())
+	if !dataSourceTypeRegistered(dataSources, "pfsense_haproxy_apply") {
+		t.Fatalf("pfsense_haproxy_apply data source was not registered")
+	}
 	if !dataSourceTypeRegistered(dataSources, "pfsense_haproxy_settings") {
 		t.Fatalf("pfsense_haproxy_settings data source was not registered")
 	}
@@ -356,7 +362,7 @@ func haproxySettingsDataSourceSchema(t *testing.T) datasourceschema.Schema {
 	return resp.Schema
 }
 
-func testResourcePlan(t *testing.T, schema resourceschema.Schema, model haproxySettingsModel) tfsdk.Plan {
+func testResourcePlan(t *testing.T, schema resourceschema.Schema, model any) tfsdk.Plan {
 	t.Helper()
 
 	plan := tfsdk.Plan{Schema: schema}
@@ -368,7 +374,7 @@ func testResourcePlan(t *testing.T, schema resourceschema.Schema, model haproxyS
 	return plan
 }
 
-func testResourceState(t *testing.T, schema resourceschema.Schema, model haproxySettingsModel) tfsdk.State {
+func testResourceState(t *testing.T, schema resourceschema.Schema, model any) tfsdk.State {
 	t.Helper()
 
 	state := tfsdk.State{Schema: schema}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -118,12 +118,14 @@ func (p *haproxyProvider) Configure(ctx context.Context, req provider.ConfigureR
 
 func (p *haproxyProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		newHaproxyApplyResource,
 		newHaproxySettingsResource,
 	}
 }
 
 func (p *haproxyProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		newHaproxyApplyDataSource,
 		newHaproxySettingsDataSource,
 	}
 }


### PR DESCRIPTION
## Summary
- add explicit pfsense_haproxy_apply resource and matching status data source
- call POST /services/haproxy/apply only from the apply resource lifecycle, with GET polling until applied=true
- document UAT-pending HAProxyApply assumptions and example trigger usage

## Tests
- terraform fmt -recursive examples
- make lint
- make test
- go test ./...

## Limitations
- live UAT endpoint response shape and apply behavior remain pending because this environment cannot reach the approved UAT firewall; docs carry the assumed HAProxyApply applied-boolean contract

Refs #7