### PR TITLE
M3-01 Implement HAProxy backend resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Terraform provider for managing the pfSense HAProxy package through `pfSense-pkg
 ## Status
 
 Bootstrap scaffold is in place. `pfsense_haproxy_settings` is implemented with
-an import-first ownership model, and `pfsense_haproxy_apply` provides an
-explicit apply/reload lifecycle. Additional HAProxy resources are tracked
-through GitHub issues and milestones.
+an import-first ownership model, `pfsense_haproxy_apply` provides an explicit
+apply/reload lifecycle, and `pfsense_haproxy_backend` manages top-level HAProxy
+backends by natural name. Additional HAProxy resources are tracked through
+GitHub issues and milestones.
 
 ## Requirements
 
@@ -125,6 +126,34 @@ UAT validation is still pending. The implementation assumes the pfREST
 `applied` boolean, and `POST /services/haproxy/apply` starts HAProxy
 configuration application.
 
+## HAProxy backends
+
+`resource "pfsense_haproxy_backend"` manages top-level HAProxy backends:
+
+- Create sends `POST /services/haproxy/backend`.
+- Read resolves by backend name with `GET /services/haproxy/backends?name=...`.
+- Update resolves the current pfSense object ID by name, then sends
+  `PATCH /services/haproxy/backend` with that ID and changed scalar fields.
+- Delete resolves the current pfSense object ID by name, then sends
+  `DELETE /services/haproxy/backend?id=...`.
+- Import uses the backend name, for example
+  `terraform import pfsense_haproxy_backend.app app_backend`.
+- No HAProxy apply/reload is triggered by this resource.
+
+Terraform state uses the backend name as the stable ID because pfSense object
+IDs are implementation details and may not be durable across config rewrites.
+The resource schema is intentionally conservative: it exposes the backend name
+and selected scalar fields needed for common backend creation, including health
+check, agent check, and cookie persistence controls. Nested servers, ACLs,
+actions, error files, stats, and advanced pass-through text remain out of scope
+until their ownership and sensitivity model is validated.
+
+UAT validation is still pending. The implementation assumes
+`GET /services/haproxy/backends?name=...` returns backend objects with `id` and
+`name`, the singular backend write endpoints accept the documented pfREST
+`HAProxyBackend` scalar field names, and backend writes do not apply pending
+HAProxy changes unless a separate `pfsense_haproxy_apply` resource is used.
+
 ## Development
 
 ```bash
@@ -138,11 +167,11 @@ make testacc
 ## Resources
 
 - `pfsense_haproxy_apply`
+- `pfsense_haproxy_backend`
 - `pfsense_haproxy_settings`
 
 ## Planned resources
 
-- `pfsense_haproxy_backend`
 - `pfsense_haproxy_backend_server`
 - `pfsense_haproxy_frontend`
 - `pfsense_haproxy_frontend_address`
@@ -155,21 +184,34 @@ make testacc
 
 ```hcl
 resource "pfsense_haproxy_backend" "addressvalidator" {
-  name = "addressvalidator_uat"
-  mode = "http"
+  name                = "addressvalidator_uat"
+  balance             = "roundrobin"
+  connection_timeout  = 30000
+  server_timeout      = 30000
+  check_type          = "HTTP"
+  checkinter          = 2000
+  httpcheck_method    = "GET"
+  monitor_uri         = "/health"
+  monitor_httpversion = "HTTP/1.1"
 }
 
-resource "pfsense_haproxy_backend_server" "addressvalidator_01" {
-  backend = pfsense_haproxy_backend.addressvalidator.name
-  name    = "01-gts-u-addressvalidator"
-  address = "192.168.31.101"
-  port    = 8080
-  check   = true
+resource "pfsense_haproxy_apply" "addressvalidator" {
+  depends_on = [pfsense_haproxy_backend.addressvalidator]
+
+  triggers = {
+    backend = sha1(jsonencode({
+      name           = pfsense_haproxy_backend.addressvalidator.name
+      balance        = pfsense_haproxy_backend.addressvalidator.balance
+      check_type     = pfsense_haproxy_backend.addressvalidator.check_type
+      monitor_uri    = pfsense_haproxy_backend.addressvalidator.monitor_uri
+      server_timeout = pfsense_haproxy_backend.addressvalidator.server_timeout
+    }))
+  }
 }
 ```
 
-Remaining resource schemas will be finalized from approved UAT pfSense REST API
-endpoint responses before production use.
+Backend server resources and remaining schemas will be finalized from approved
+UAT pfSense REST API endpoint responses before production use.
 
 ## Schema inventory
 

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -83,3 +83,11 @@ assumed to return an `applied` boolean, and `POST /services/haproxy/apply` is
 assumed to start HAProxy configuration application. The Terraform resource keeps
 apply explicit with user-controlled `triggers`; settings and other durable
 resources must not auto-apply pending changes.
+
+For M3-01, `pfsense_haproxy_backend` uses the upstream `HAProxyBackend.inc`
+model as a conservative implementation reference. Terraform stores backend
+names as stable natural keys, resolves the current pfSense object ID from
+`GET /services/haproxy/backends?name=...` before update/delete, and manages only
+selected scalar fields. Nested backend servers, ACLs, actions, error files,
+stats, and advanced pass-through fields remain pending UAT confirmation and
+separate ownership decisions.

--- a/docs/schema/resource-schema-decisions.md
+++ b/docs/schema/resource-schema-decisions.md
@@ -39,7 +39,7 @@ Primary references:
 | Terraform resource | API model | Primary endpoints | Documented create/update shape | Decision |
 |--------------------|-----------|-------------------|--------------------------------|----------|
 | `pfsense_haproxy_settings` | HAProxySettings | `GET/PATCH /api/v2/services/haproxy/settings` | Settings patch body is partial; no create/delete. | Implemented as split model in M2-01: data source reads settings; resource is singleton import-first with fixed ID `settings`, create blocked, update PATCH only, delete state-only, no apply/reload. |
-| `pfsense_haproxy_backend` | HAProxyBackend | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend`; `GET /backends` | Create requires `name`, `agent_port`, and `persist_cookie_name` in public OpenAPI. Patch requires `id`. | Durable top-level resource. Keep embedded collections read-only or ignored when managed by child resources. |
+| `pfsense_haproxy_backend` | HAProxyBackend | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend`; `GET /backends` | Create requires `name`; public OpenAPI also marks conditional `agent_port` and `persist_cookie_name` as required when agent checks or cookie persistence are enabled. Patch requires `id`. | Implemented in M3-01 as a durable top-level resource using backend `name` as Terraform's stable natural key. Before update/delete, resolve pfSense's current object ID from `GET /backends?name=...`. Manage selected scalar fields only; keep embedded servers, ACLs, actions, error files, stats, and advanced pass-through fields out of scope pending UAT ownership confirmation. |
 | `pfsense_haproxy_backend_server` | HAProxyBackendServer | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/server` | Create requires `parent_id`, `name`, `address`, `port`. Patch requires `parent_id`, `id`. | Child resource under backend. Terraform ID must retain backend API ID and server API ID. |
 | `pfsense_haproxy_backend_acl` | HAProxyBackendACL | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/acl` | Create requires `parent_id`, `name`, `expression`, `value`. Patch requires `parent_id`, `id`. | Child resource under backend. |
 | `pfsense_haproxy_backend_action` | HAProxyBackendAction | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/action` | Create requires `parent_id` plus action-specific fields in the public schema. | Child resource under backend. Conditional fields need UAT examples before strict Terraform validation. |
@@ -69,11 +69,15 @@ Primary references:
   field on UAT and whether any extra error/status fields should be exposed.
 - Confirm `POST /api/v2/services/haproxy/apply` returns quickly enough for the
   current poll defaults or whether UAT needs different timeout guidance.
-- Exact response envelope for create/update/delete, including where object IDs are
-  returned.
+- Exact response envelope for create/update/delete, including whether object IDs
+  are returned directly or must always be rediscovered from plural GET endpoints.
 - Whether UAT uses numeric IDs, string IDs, or mixed IDs for every HAProxy model.
-- Whether published required fields such as `agent_port` and
-  `persist_cookie_name` are truly required by UAT for backend creation.
+- Confirm `GET /api/v2/services/haproxy/backends?name=...` returns exact-name
+  matches or, at minimum, a list containing `id` and `name` fields that can be
+  filtered client-side.
+- Whether published conditional fields such as `agent_port` and
+  `persist_cookie_name` are required only when their enabling booleans are true
+  on UAT.
 - Whether conditional action fields can be omitted when unrelated to the chosen
   action.
 - Whether HAProxy and HAProxy-devel expose identical schema paths on this UAT

--- a/examples/haproxy_backend.tf
+++ b/examples/haproxy_backend.tf
@@ -1,0 +1,40 @@
+resource "pfsense_haproxy_backend" "app" {
+  name                = "app_uat"
+  balance             = "roundrobin"
+  connection_timeout  = 30000
+  server_timeout      = 30000
+  check_type          = "HTTP"
+  checkinter          = 2000
+  log_health_checks   = true
+  httpcheck_method    = "GET"
+  monitor_uri         = "/health"
+  monitor_httpversion = "HTTP/1.1"
+}
+
+# Explicit apply after backend changes. There is intentionally no hidden
+# auto-apply in pfsense_haproxy_backend or other durable HAProxy resources.
+#
+# UAT note: this assumes GET /services/haproxy/backends returns objects with
+# stable names and transient pfSense IDs, and that POST/PATCH/DELETE backend
+# writes only mark HAProxy configuration pending until pfsense_haproxy_apply runs.
+resource "pfsense_haproxy_apply" "app_backend" {
+  depends_on = [pfsense_haproxy_backend.app]
+
+  triggers = {
+    backend = sha1(jsonencode({
+      name                = pfsense_haproxy_backend.app.name
+      balance             = pfsense_haproxy_backend.app.balance
+      connection_timeout  = pfsense_haproxy_backend.app.connection_timeout
+      server_timeout      = pfsense_haproxy_backend.app.server_timeout
+      check_type          = pfsense_haproxy_backend.app.check_type
+      checkinter          = pfsense_haproxy_backend.app.checkinter
+      log_health_checks   = pfsense_haproxy_backend.app.log_health_checks
+      httpcheck_method    = pfsense_haproxy_backend.app.httpcheck_method
+      monitor_uri         = pfsense_haproxy_backend.app.monitor_uri
+      monitor_httpversion = pfsense_haproxy_backend.app.monitor_httpversion
+    }))
+  }
+
+  timeout       = "2m"
+  poll_interval = "2s"
+}

--- a/internal/provider/haproxy_backend.go
+++ b/internal/provider/haproxy_backend.go
@@ -1,0 +1,685 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	haproxyBackendPath  = "/services/haproxy/backend"
+	haproxyBackendsPath = "/services/haproxy/backends"
+)
+
+var (
+	_ resource.Resource                = (*haproxyBackendResource)(nil)
+	_ resource.ResourceWithConfigure   = (*haproxyBackendResource)(nil)
+	_ resource.ResourceWithImportState = (*haproxyBackendResource)(nil)
+)
+
+type backendAttributeKind string
+
+const (
+	backendAttributeBool   backendAttributeKind = "bool"
+	backendAttributeInt64  backendAttributeKind = "int64"
+	backendAttributeString backendAttributeKind = "string"
+)
+
+type backendAttribute struct {
+	Name        string
+	JSONName    string
+	Kind        backendAttributeKind
+	Description string
+}
+
+var haproxyBackendAttributes = []backendAttribute{
+	{Name: "balance", JSONName: "balance", Kind: backendAttributeString, Description: "Load-balancing algorithm for this backend, such as roundrobin, static-rr, leastconn, source, or uri. Empty uses the pfSense HAProxy package default."},
+	{Name: "connection_timeout", JSONName: "connection_timeout", Kind: backendAttributeInt64, Description: "Connection timeout in milliseconds. Null leaves the pfSense HAProxy package default in place."},
+	{Name: "server_timeout", JSONName: "server_timeout", Kind: backendAttributeInt64, Description: "Server data timeout in milliseconds. Null leaves the pfSense HAProxy package default in place."},
+	{Name: "retries", JSONName: "retries", Kind: backendAttributeInt64, Description: "Retry attempts after a backend server connection failure."},
+	{Name: "check_type", JSONName: "check_type", Kind: backendAttributeString, Description: "Backend health check method, such as none, Basic, HTTP, LDAP, MySQL, PostgreSQL, Redis, SMTP, ESMTP, or SSL."},
+	{Name: "checkinter", JSONName: "checkinter", Kind: backendAttributeInt64, Description: "Health check interval in milliseconds when check_type is not none."},
+	{Name: "log_health_checks", JSONName: "log_health_checks", Kind: backendAttributeBool, Description: "Enable or disable logging health check status changes."},
+	{Name: "httpcheck_method", JSONName: "httpcheck_method", Kind: backendAttributeString, Description: "HTTP method used for HTTP health checks."},
+	{Name: "monitor_uri", JSONName: "monitor_uri", Kind: backendAttributeString, Description: "URI used for HTTP health checks."},
+	{Name: "monitor_httpversion", JSONName: "monitor_httpversion", Kind: backendAttributeString, Description: "HTTP version used for HTTP health checks."},
+	{Name: "agent_checks", JSONName: "agent_checks", Kind: backendAttributeBool, Description: "Enable or disable HAProxy agent checks for this backend."},
+	{Name: "agent_port", JSONName: "agent_port", Kind: backendAttributeString, Description: "TCP port used for HAProxy agent checks. Required by pfREST when agent_checks is true."},
+	{Name: "agent_inter", JSONName: "agent_inter", Kind: backendAttributeInt64, Description: "Interval in milliseconds between HAProxy agent checks."},
+	{Name: "persist_cookie_enabled", JSONName: "persist_cookie_enabled", Kind: backendAttributeBool, Description: "Enable or disable cookie-based persistence."},
+	{Name: "persist_cookie_name", JSONName: "persist_cookie_name", Kind: backendAttributeString, Description: "Cookie name used for persistence. Required by pfREST when persist_cookie_enabled is true."},
+	{Name: "persist_cookie_mode", JSONName: "persist_cookie_mode", Kind: backendAttributeString, Description: "HAProxy cookie persistence mode."},
+}
+
+type haproxyBackendResource struct {
+	client *pfsense.Client
+}
+
+type haproxyBackendModel struct {
+	ID                   types.String `tfsdk:"id"`
+	Name                 types.String `tfsdk:"name"`
+	Balance              types.String `tfsdk:"balance"`
+	ConnectionTimeout    types.Int64  `tfsdk:"connection_timeout"`
+	ServerTimeout        types.Int64  `tfsdk:"server_timeout"`
+	Retries              types.Int64  `tfsdk:"retries"`
+	CheckType            types.String `tfsdk:"check_type"`
+	CheckInterval        types.Int64  `tfsdk:"checkinter"`
+	LogHealthChecks      types.Bool   `tfsdk:"log_health_checks"`
+	HTTPCheckMethod      types.String `tfsdk:"httpcheck_method"`
+	MonitorURI           types.String `tfsdk:"monitor_uri"`
+	MonitorHTTPVersion   types.String `tfsdk:"monitor_httpversion"`
+	AgentChecks          types.Bool   `tfsdk:"agent_checks"`
+	AgentPort            types.String `tfsdk:"agent_port"`
+	AgentInterval        types.Int64  `tfsdk:"agent_inter"`
+	PersistCookieEnabled types.Bool   `tfsdk:"persist_cookie_enabled"`
+	PersistCookieName    types.String `tfsdk:"persist_cookie_name"`
+	PersistCookieMode    types.String `tfsdk:"persist_cookie_mode"`
+}
+
+func newHaproxyBackendResource() resource.Resource {
+	return &haproxyBackendResource{}
+}
+
+func (r *haproxyBackendResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "pfsense_haproxy_backend"
+}
+
+func (r *haproxyBackendResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resourceschema.Schema{
+		Description: "Manages a pfSense HAProxy backend through pfSense-pkg-RESTAPI. Terraform uses the backend name as the stable ID and resolves pfSense's current object ID before writes because pfSense object IDs may not be durable.",
+		Attributes:  haproxyBackendResourceSchemaAttributes(),
+	}
+}
+
+func (r *haproxyBackendResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*pfsense.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected resource configure type", fmt.Sprintf("Expected *pfsense.Client, got %T.", req.ProviderData))
+		return
+	}
+
+	r.client = client
+}
+
+func (r *haproxyBackendResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before creating pfsense_haproxy_backend.")
+		return
+	}
+
+	var plan haproxyBackendModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name, err := haproxyBackendName(plan.Name)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend name", err.Error())
+		return
+	}
+
+	_, _, found, err := findHaproxyBackendByName(ctx, r.client, name)
+	if err != nil {
+		resp.Diagnostics.AddError("Check existing HAProxy backend failed", backendLookupErrorDetail(name, err))
+		return
+	}
+	if found {
+		resp.Diagnostics.AddError(
+			"HAProxy backend already exists",
+			fmt.Sprintf("A pfSense HAProxy backend named %q already exists. Import it with `terraform import pfsense_haproxy_backend.<name> %s` before managing it.", name, name),
+		)
+		return
+	}
+
+	if err := r.client.Post(ctx, haproxyBackendPath, buildHaproxyBackendCreatePayload(plan, name), nil); err != nil {
+		resp.Diagnostics.AddError("Create HAProxy backend failed", err.Error())
+		return
+	}
+
+	backend, _, found, err := findHaproxyBackendByName(ctx, r.client, name)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy backend after create failed", backendLookupErrorDetail(name, err))
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError(
+			"Read HAProxy backend after create failed",
+			fmt.Sprintf("Created backend %q but GET %s did not return it. Confirm the live UAT /services/haproxy/backends response shape and natural-key filtering before relying on this resource.", name, haproxyBackendsPath),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, backend)...)
+}
+
+func (r *haproxyBackendResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before reading pfsense_haproxy_backend.")
+		return
+	}
+
+	var state haproxyBackendModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name, err := haproxyBackendStateName(state)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend state", err.Error())
+		return
+	}
+
+	backend, _, found, err := findHaproxyBackendByName(ctx, r.client, name)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy backend failed", backendLookupErrorDetail(name, err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, backend)...)
+}
+
+func (r *haproxyBackendResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before updating pfsense_haproxy_backend.")
+		return
+	}
+
+	var plan, prior haproxyBackendModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name, err := haproxyBackendName(plan.Name)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend name", err.Error())
+		return
+	}
+	priorName, err := haproxyBackendStateName(prior)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend prior state", err.Error())
+		return
+	}
+	if name != priorName {
+		resp.Diagnostics.AddError("Renaming HAProxy backends is not supported", "The backend name is the Terraform natural key. Change the name by creating a new resource and deleting the old one.")
+		return
+	}
+
+	_, apiID, found, err := findHaproxyBackendByName(ctx, r.client, name)
+	if err != nil {
+		resp.Diagnostics.AddError("Find HAProxy backend before update failed", backendLookupErrorDetail(name, err))
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError("Update HAProxy backend failed", fmt.Sprintf("Backend %q was not found on pfSense. Recreate it or remove it from Terraform state.", name))
+		return
+	}
+
+	patch := buildHaproxyBackendPatch(plan, prior, apiID)
+	if len(patch) > 1 {
+		if err := r.client.Patch(ctx, haproxyBackendPath, patch, nil); err != nil {
+			resp.Diagnostics.AddError("Update HAProxy backend failed", err.Error())
+			return
+		}
+	}
+
+	backend, _, found, err := findHaproxyBackendByName(ctx, r.client, name)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy backend after update failed", backendLookupErrorDetail(name, err))
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError("Read HAProxy backend after update failed", fmt.Sprintf("Backend %q was not returned by GET %s after PATCH.", name, haproxyBackendsPath))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, backend)...)
+}
+
+func (r *haproxyBackendResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before deleting pfsense_haproxy_backend.")
+		return
+	}
+
+	var state haproxyBackendModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name, err := haproxyBackendStateName(state)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend state", err.Error())
+		return
+	}
+
+	_, apiID, found, err := findHaproxyBackendByName(ctx, r.client, name)
+	if err != nil {
+		resp.Diagnostics.AddError("Find HAProxy backend before delete failed", backendLookupErrorDetail(name, err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if err := r.client.Delete(ctx, haproxyBackendDeletePath(apiID), nil); err != nil {
+		resp.Diagnostics.AddError("Delete HAProxy backend failed", err.Error())
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *haproxyBackendResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	name := strings.TrimSpace(req.ID)
+	if name == "" {
+		resp.Diagnostics.AddError("Invalid HAProxy backend import ID", "Import pfsense_haproxy_backend with the backend name.")
+		return
+	}
+
+	model := nullHaproxyBackendModel()
+	model.ID = types.StringValue(name)
+	model.Name = types.StringValue(name)
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func haproxyBackendResourceSchemaAttributes() map[string]resourceschema.Attribute {
+	attributes := map[string]resourceschema.Attribute{
+		"id": resourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Stable Terraform ID for the backend. This is the backend name, not the pfSense object ID.",
+		},
+		"name": resourceschema.StringAttribute{
+			Required:    true,
+			Description: "Unique HAProxy backend name. pfSense restricts names to letters, numbers, dot, hyphen, and underscore. Terraform treats this as the natural key and requires replacement if it changes.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+	}
+
+	for _, attribute := range haproxyBackendAttributes {
+		switch attribute.Kind {
+		case backendAttributeBool:
+			attributes[attribute.Name] = resourceschema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: attribute.Description,
+			}
+		case backendAttributeInt64:
+			attributes[attribute.Name] = resourceschema.Int64Attribute{
+				Optional:    true,
+				Computed:    true,
+				Description: attribute.Description,
+			}
+		case backendAttributeString:
+			attributes[attribute.Name] = resourceschema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: attribute.Description,
+			}
+		}
+	}
+
+	return attributes
+}
+
+func buildHaproxyBackendCreatePayload(plan haproxyBackendModel, name string) map[string]any {
+	payload := map[string]any{
+		"name": name,
+	}
+	values := plan.attrValues()
+
+	for _, attribute := range haproxyBackendAttributes {
+		planned := values[attribute.Name]
+		if planned.IsNull() || planned.IsUnknown() {
+			continue
+		}
+		payload[attribute.JSONName] = backendTerraformValueToJSON(attribute.Kind, planned)
+	}
+
+	return payload
+}
+
+func buildHaproxyBackendPatch(plan haproxyBackendModel, prior haproxyBackendModel, apiID string) map[string]any {
+	patch := map[string]any{
+		"id": apiID,
+	}
+	planValues := plan.attrValues()
+	priorValues := prior.attrValues()
+
+	for _, attribute := range haproxyBackendAttributes {
+		planned := planValues[attribute.Name]
+		if planned.IsUnknown() {
+			continue
+		}
+		if planned.Equal(priorValues[attribute.Name]) {
+			continue
+		}
+
+		patch[attribute.JSONName] = backendTerraformValueToJSON(attribute.Kind, planned)
+	}
+
+	return patch
+}
+
+func findHaproxyBackendByName(ctx context.Context, client *pfsense.Client, name string) (haproxyBackendModel, string, bool, error) {
+	var raw any
+	if err := client.Get(ctx, haproxyBackendsQueryPath(name), &raw); err != nil {
+		return haproxyBackendModel{}, "", false, err
+	}
+
+	payloads, err := haproxyBackendPayloadList(raw)
+	if err != nil {
+		return haproxyBackendModel{}, "", false, err
+	}
+
+	var matched map[string]any
+	for _, payload := range payloads {
+		candidateName, err := apiRequiredStringWithLabel(payload, "HAProxy backend", "name")
+		if err != nil {
+			return haproxyBackendModel{}, "", false, err
+		}
+		if candidateName != name {
+			continue
+		}
+		if matched != nil {
+			return haproxyBackendModel{}, "", false, fmt.Errorf("multiple HAProxy backends named %q were returned; backend names must be unique for Terraform natural-key management", name)
+		}
+		matched = payload
+	}
+
+	if matched == nil {
+		return haproxyBackendModel{}, "", false, nil
+	}
+
+	apiID, err := apiRequiredScalarStringWithLabel(matched, "HAProxy backend", "id")
+	if err != nil {
+		return haproxyBackendModel{}, "", false, fmt.Errorf("%w; confirm UAT returns object IDs from GET %s before using update/delete", err, haproxyBackendsPath)
+	}
+	model, err := haproxyBackendModelFromAPI(matched)
+	if err != nil {
+		return haproxyBackendModel{}, "", false, err
+	}
+
+	return model, apiID, true, nil
+}
+
+func haproxyBackendPayloadList(raw any) ([]map[string]any, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	switch typed := raw.(type) {
+	case []any:
+		payloads := make([]map[string]any, 0, len(typed))
+		for index, item := range typed {
+			payload, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("HAProxy backends response item %d has unsupported type %T", index, item)
+			}
+			payloads = append(payloads, payload)
+		}
+		return payloads, nil
+	case []map[string]any:
+		return typed, nil
+	case map[string]any:
+		return []map[string]any{typed}, nil
+	default:
+		return nil, fmt.Errorf("HAProxy backends response has unsupported type %T; confirm the live UAT /services/haproxy/backends schema", raw)
+	}
+}
+
+func haproxyBackendModelFromAPI(payload map[string]any) (haproxyBackendModel, error) {
+	backend := nullHaproxyBackendModel()
+
+	name, err := apiRequiredStringWithLabel(payload, "HAProxy backend", "name")
+	if err != nil {
+		return backend, err
+	}
+	backend.ID = types.StringValue(name)
+	backend.Name = types.StringValue(name)
+
+	if backend.Balance, err = apiStringWithLabel(payload, "HAProxy backend", "balance"); err != nil {
+		return backend, err
+	}
+	if backend.ConnectionTimeout, err = apiInt64WithLabel(payload, "HAProxy backend", "connection_timeout"); err != nil {
+		return backend, err
+	}
+	if backend.ServerTimeout, err = apiInt64WithLabel(payload, "HAProxy backend", "server_timeout"); err != nil {
+		return backend, err
+	}
+	if backend.Retries, err = apiInt64WithLabel(payload, "HAProxy backend", "retries"); err != nil {
+		return backend, err
+	}
+	if backend.CheckType, err = apiStringWithLabel(payload, "HAProxy backend", "check_type"); err != nil {
+		return backend, err
+	}
+	if backend.CheckInterval, err = apiInt64WithLabel(payload, "HAProxy backend", "checkinter"); err != nil {
+		return backend, err
+	}
+	if backend.LogHealthChecks, err = apiBoolWithLabel(payload, "HAProxy backend", "log_health_checks"); err != nil {
+		return backend, err
+	}
+	if backend.HTTPCheckMethod, err = apiStringWithLabel(payload, "HAProxy backend", "httpcheck_method"); err != nil {
+		return backend, err
+	}
+	if backend.MonitorURI, err = apiStringWithLabel(payload, "HAProxy backend", "monitor_uri"); err != nil {
+		return backend, err
+	}
+	if backend.MonitorHTTPVersion, err = apiStringWithLabel(payload, "HAProxy backend", "monitor_httpversion"); err != nil {
+		return backend, err
+	}
+	if backend.AgentChecks, err = apiBoolWithLabel(payload, "HAProxy backend", "agent_checks"); err != nil {
+		return backend, err
+	}
+	if backend.AgentPort, err = apiScalarStringWithLabel(payload, "HAProxy backend", "agent_port"); err != nil {
+		return backend, err
+	}
+	if backend.AgentInterval, err = apiInt64WithLabel(payload, "HAProxy backend", "agent_inter"); err != nil {
+		return backend, err
+	}
+	if backend.PersistCookieEnabled, err = apiBoolWithLabel(payload, "HAProxy backend", "persist_cookie_enabled"); err != nil {
+		return backend, err
+	}
+	if backend.PersistCookieName, err = apiStringWithLabel(payload, "HAProxy backend", "persist_cookie_name"); err != nil {
+		return backend, err
+	}
+	if backend.PersistCookieMode, err = apiStringWithLabel(payload, "HAProxy backend", "persist_cookie_mode"); err != nil {
+		return backend, err
+	}
+
+	return backend, nil
+}
+
+func nullHaproxyBackendModel() haproxyBackendModel {
+	return haproxyBackendModel{
+		ID:                   types.StringNull(),
+		Name:                 types.StringNull(),
+		Balance:              types.StringNull(),
+		ConnectionTimeout:    types.Int64Null(),
+		ServerTimeout:        types.Int64Null(),
+		Retries:              types.Int64Null(),
+		CheckType:            types.StringNull(),
+		CheckInterval:        types.Int64Null(),
+		LogHealthChecks:      types.BoolNull(),
+		HTTPCheckMethod:      types.StringNull(),
+		MonitorURI:           types.StringNull(),
+		MonitorHTTPVersion:   types.StringNull(),
+		AgentChecks:          types.BoolNull(),
+		AgentPort:            types.StringNull(),
+		AgentInterval:        types.Int64Null(),
+		PersistCookieEnabled: types.BoolNull(),
+		PersistCookieName:    types.StringNull(),
+		PersistCookieMode:    types.StringNull(),
+	}
+}
+
+func (m haproxyBackendModel) attrValues() map[string]attr.Value {
+	return map[string]attr.Value{
+		"balance":                m.Balance,
+		"connection_timeout":     m.ConnectionTimeout,
+		"server_timeout":         m.ServerTimeout,
+		"retries":                m.Retries,
+		"check_type":             m.CheckType,
+		"checkinter":             m.CheckInterval,
+		"log_health_checks":      m.LogHealthChecks,
+		"httpcheck_method":       m.HTTPCheckMethod,
+		"monitor_uri":            m.MonitorURI,
+		"monitor_httpversion":    m.MonitorHTTPVersion,
+		"agent_checks":           m.AgentChecks,
+		"agent_port":             m.AgentPort,
+		"agent_inter":            m.AgentInterval,
+		"persist_cookie_enabled": m.PersistCookieEnabled,
+		"persist_cookie_name":    m.PersistCookieName,
+		"persist_cookie_mode":    m.PersistCookieMode,
+	}
+}
+
+func backendTerraformValueToJSON(kind backendAttributeKind, value attr.Value) any {
+	if value.IsNull() {
+		return nil
+	}
+
+	switch kind {
+	case backendAttributeBool:
+		return value.(types.Bool).ValueBool()
+	case backendAttributeInt64:
+		return value.(types.Int64).ValueInt64()
+	case backendAttributeString:
+		return value.(types.String).ValueString()
+	default:
+		return nil
+	}
+}
+
+func haproxyBackendName(value types.String) (string, error) {
+	if value.IsNull() || value.IsUnknown() {
+		return "", fmt.Errorf("name is required")
+	}
+	name := value.ValueString()
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "", fmt.Errorf("name must not be empty")
+	}
+	if trimmed != name {
+		return "", fmt.Errorf("name must not contain leading or trailing whitespace")
+	}
+
+	return name, nil
+}
+
+func haproxyBackendStateName(model haproxyBackendModel) (string, error) {
+	if !model.Name.IsNull() && !model.Name.IsUnknown() {
+		return haproxyBackendName(model.Name)
+	}
+	if !model.ID.IsNull() && !model.ID.IsUnknown() {
+		return haproxyBackendName(model.ID)
+	}
+
+	return "", fmt.Errorf("state is missing backend name")
+}
+
+func haproxyBackendsQueryPath(name string) string {
+	values := url.Values{}
+	values.Set("name", name)
+	return haproxyBackendsPath + "?" + values.Encode()
+}
+
+func haproxyBackendDeletePath(apiID string) string {
+	values := url.Values{}
+	values.Set("id", apiID)
+	return haproxyBackendPath + "?" + values.Encode()
+}
+
+func backendLookupErrorDetail(name string, err error) string {
+	return fmt.Sprintf("%s. Confirm GET %s is available on UAT, returns a list of backend objects with stable name fields, and includes the transient pfSense object id required for update/delete. Backend name: %q.", err.Error(), haproxyBackendsPath, name)
+}
+
+func apiRequiredStringWithLabel(payload map[string]any, label string, names ...string) (string, error) {
+	value, name, ok := apiValue(payload, names...)
+	if !ok || value == nil {
+		return "", fmt.Errorf("%s response did not include required string field %q", label, names[0])
+	}
+
+	typed, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("%s field %q has unsupported string type %T", label, name, value)
+	}
+	if strings.TrimSpace(typed) == "" {
+		return "", fmt.Errorf("%s field %q must not be empty", label, name)
+	}
+
+	return typed, nil
+}
+
+func apiRequiredScalarStringWithLabel(payload map[string]any, label string, names ...string) (string, error) {
+	value, name, ok := apiValue(payload, names...)
+	if !ok || value == nil {
+		return "", fmt.Errorf("%s response did not include required scalar field %q", label, names[0])
+	}
+
+	return scalarStringValue(label, name, value)
+}
+
+func apiScalarStringWithLabel(payload map[string]any, label string, names ...string) (types.String, error) {
+	value, name, ok := apiValue(payload, names...)
+	if !ok || value == nil {
+		return types.StringNull(), nil
+	}
+
+	scalar, err := scalarStringValue(label, name, value)
+	if err != nil {
+		return types.StringNull(), err
+	}
+	if scalar == "" {
+		return types.StringNull(), nil
+	}
+
+	return types.StringValue(scalar), nil
+}
+
+func scalarStringValue(label string, name string, value any) (string, error) {
+	switch typed := value.(type) {
+	case string:
+		return typed, nil
+	case float64:
+		if math.Trunc(typed) != typed {
+			return "", fmt.Errorf("%s field %q is %v, not an integer scalar", label, name, typed)
+		}
+		return strconv.FormatInt(int64(typed), 10), nil
+	case json.Number:
+		intValue, err := typed.Int64()
+		if err != nil {
+			return "", fmt.Errorf("%s field %q is %q, not an integer scalar: %w", label, name, typed.String(), err)
+		}
+		return strconv.FormatInt(intValue, 10), nil
+	default:
+		return "", fmt.Errorf("%s field %q has unsupported scalar type %T", label, name, value)
+	}
+}

--- a/internal/provider/haproxy_backend_test.go
+++ b/internal/provider/haproxy_backend_test.go
@@ -1,0 +1,523 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestHaproxyBackendResourceCreateUsesNaturalKeyLookupAndDoesNotApply(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	var postPayload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v2/services/haproxy/backends":
+			if got := r.URL.Query().Get("name"); got != "app_backend" {
+				t.Fatalf("backend lookup name = %q", got)
+			}
+			mu.Lock()
+			callNumber := len(requests)
+			mu.Unlock()
+			if callNumber == 1 {
+				_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{
+				"code": 200,
+				"status": "ok",
+				"data": [{
+					"id": 42,
+					"name": "app_backend",
+					"balance": "roundrobin",
+					"connection_timeout": 15000,
+					"server_timeout": "30000",
+					"check_type": "HTTP",
+					"checkinter": "2000",
+					"log_health_checks": "yes",
+					"httpcheck_method": "GET",
+					"monitor_uri": "/health",
+					"monitor_httpversion": "HTTP/1.1",
+					"agent_checks": false,
+					"persist_cookie_enabled": false
+				}]
+			}`))
+		case http.MethodPost + " /api/v2/services/haproxy/backend":
+			if err := json.NewDecoder(r.Body).Decode(&postPayload); err != nil {
+				t.Fatalf("decode POST payload: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"id":42}}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	backendResource := &haproxyBackendResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendResourceSchema(t)
+	plan := nullHaproxyBackendModel()
+	plan.Name = types.StringValue("app_backend")
+	plan.Balance = types.StringValue("roundrobin")
+	plan.ConnectionTimeout = types.Int64Value(15000)
+	plan.ServerTimeout = types.Int64Value(30000)
+	plan.CheckType = types.StringValue("HTTP")
+	plan.CheckInterval = types.Int64Value(2000)
+	plan.LogHealthChecks = types.BoolValue(true)
+	plan.HTTPCheckMethod = types.StringValue("GET")
+	plan.MonitorURI = types.StringValue("/health")
+	plan.MonitorHTTPVersion = types.StringValue("HTTP/1.1")
+
+	resp := resource.CreateResponse{
+		State: testResourceState(t, schema, plan),
+	}
+	backendResource.Create(context.Background(), resource.CreateRequest{
+		Plan: testResourcePlan(t, schema, plan),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/backends?name=app_backend",
+		"POST /api/v2/services/haproxy/backend",
+		"GET /api/v2/services/haproxy/backends?name=app_backend",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+
+	if postPayload["name"] != "app_backend" {
+		t.Fatalf("POST name = %#v", postPayload["name"])
+	}
+	if postPayload["balance"] != "roundrobin" {
+		t.Fatalf("POST balance = %#v", postPayload["balance"])
+	}
+	if postPayload["connection_timeout"] != float64(15000) {
+		t.Fatalf("POST connection_timeout = %#v", postPayload["connection_timeout"])
+	}
+	for _, forbidden := range []string{"id", "apply", "async", "servers", "acls", "actions"} {
+		if _, ok := postPayload[forbidden]; ok {
+			t.Fatalf("POST unexpectedly included %q: %#v", forbidden, postPayload)
+		}
+	}
+
+	var state haproxyBackendModel
+	diags := resp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.ID.ValueString() != "app_backend" || state.Name.ValueString() != "app_backend" {
+		t.Fatalf("natural key not preserved in state: %#v", state)
+	}
+	if state.ServerTimeout.ValueInt64() != 30000 || !state.LogHealthChecks.ValueBool() {
+		t.Fatalf("state was not refreshed from API defaults: %#v", state)
+	}
+}
+
+func TestHaproxyBackendResourceCreateRejectsExistingBackend(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Method != http.MethodGet || r.URL.RequestURI() != "/api/v2/services/haproxy/backends?name=app_backend" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":7,"name":"app_backend"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	backendResource := &haproxyBackendResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendResourceSchema(t)
+	plan := nullHaproxyBackendModel()
+	plan.Name = types.StringValue("app_backend")
+
+	var resp resource.CreateResponse
+	resp.State = testResourceState(t, schema, plan)
+	backendResource.Create(context.Background(), resource.CreateRequest{
+		Plan: testResourcePlan(t, schema, plan),
+	}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected existing backend diagnostic")
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("requests = %d", requests.Load())
+	}
+	if !strings.Contains(diagnosticsText(resp.Diagnostics), "terraform import") {
+		t.Fatalf("diagnostics did not include import guidance: %s", diagnosticsText(resp.Diagnostics))
+	}
+}
+
+func TestHaproxyBackendResourceReadRemovesMissingNaturalKey(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.RequestURI() != "/api/v2/services/haproxy/backends?name=missing_backend" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	backendResource := &haproxyBackendResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendResourceSchema(t)
+	stateModel := nullHaproxyBackendModel()
+	stateModel.ID = types.StringValue("missing_backend")
+	stateModel.Name = types.StringValue("missing_backend")
+
+	resp := resource.ReadResponse{
+		State: testResourceState(t, schema, stateModel),
+	}
+	backendResource.Read(context.Background(), resource.ReadRequest{
+		State: testResourceState(t, schema, stateModel),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatalf("missing backend did not remove state")
+	}
+}
+
+func TestHaproxyBackendResourceUpdatePatchesChangedFieldsOnly(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	var patchPayload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v2/services/haproxy/backends":
+			if got := r.URL.Query().Get("name"); got != "app_backend" {
+				t.Fatalf("backend lookup name = %q", got)
+			}
+			_, _ = w.Write([]byte(`{
+				"code": 200,
+				"status": "ok",
+				"data": [{
+					"id": "42",
+					"name": "app_backend",
+					"balance": "leastconn",
+					"connection_timeout": 10000,
+					"server_timeout": 45000,
+					"check_type": "HTTP",
+					"checkinter": 5000,
+					"log_health_checks": true,
+					"httpcheck_method": "HEAD",
+					"monitor_uri": "/ready",
+					"monitor_httpversion": "HTTP/1.1",
+					"agent_checks": true,
+					"agent_port": 2200,
+					"agent_inter": 3000,
+					"persist_cookie_enabled": true,
+					"persist_cookie_name": "SRV",
+					"persist_cookie_mode": "insert-only"
+				}]
+			}`))
+		case http.MethodPatch + " /api/v2/services/haproxy/backend":
+			if err := json.NewDecoder(r.Body).Decode(&patchPayload); err != nil {
+				t.Fatalf("decode PATCH payload: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":null}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	backendResource := &haproxyBackendResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendResourceSchema(t)
+
+	prior := nullHaproxyBackendModel()
+	prior.ID = types.StringValue("app_backend")
+	prior.Name = types.StringValue("app_backend")
+	prior.Balance = types.StringValue("roundrobin")
+	prior.ConnectionTimeout = types.Int64Value(10000)
+	prior.ServerTimeout = types.Int64Value(30000)
+	prior.CheckType = types.StringValue("HTTP")
+	prior.CheckInterval = types.Int64Value(5000)
+	prior.LogHealthChecks = types.BoolValue(false)
+	prior.HTTPCheckMethod = types.StringValue("HEAD")
+	prior.MonitorURI = types.StringValue("/ready")
+	prior.MonitorHTTPVersion = types.StringValue("HTTP/1.1")
+	prior.AgentChecks = types.BoolValue(false)
+	prior.PersistCookieEnabled = types.BoolValue(false)
+
+	plan := prior
+	plan.Balance = types.StringValue("leastconn")
+	plan.ServerTimeout = types.Int64Value(45000)
+	plan.LogHealthChecks = types.BoolValue(true)
+	plan.AgentChecks = types.BoolValue(true)
+	plan.AgentPort = types.StringValue("2200")
+	plan.AgentInterval = types.Int64Value(3000)
+	plan.PersistCookieEnabled = types.BoolValue(true)
+	plan.PersistCookieName = types.StringValue("SRV")
+	plan.PersistCookieMode = types.StringValue("insert-only")
+
+	resp := resource.UpdateResponse{
+		State: testResourceState(t, schema, prior),
+	}
+	backendResource.Update(context.Background(), resource.UpdateRequest{
+		Plan:  testResourcePlan(t, schema, plan),
+		State: testResourceState(t, schema, prior),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/backends?name=app_backend",
+		"PATCH /api/v2/services/haproxy/backend",
+		"GET /api/v2/services/haproxy/backends?name=app_backend",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+
+	if patchPayload["id"] != "42" {
+		t.Fatalf("patch id = %#v", patchPayload["id"])
+	}
+	if patchPayload["balance"] != "leastconn" {
+		t.Fatalf("patch balance = %#v", patchPayload["balance"])
+	}
+	if patchPayload["server_timeout"] != float64(45000) {
+		t.Fatalf("patch server_timeout = %#v", patchPayload["server_timeout"])
+	}
+	if patchPayload["log_health_checks"] != true {
+		t.Fatalf("patch log_health_checks = %#v", patchPayload["log_health_checks"])
+	}
+	if patchPayload["agent_port"] != "2200" {
+		t.Fatalf("patch agent_port = %#v", patchPayload["agent_port"])
+	}
+	if patchPayload["persist_cookie_name"] != "SRV" {
+		t.Fatalf("patch persist_cookie_name = %#v", patchPayload["persist_cookie_name"])
+	}
+	for _, forbidden := range []string{"name", "apply", "async", "connection_timeout", "check_type", "servers", "acls", "actions"} {
+		if _, ok := patchPayload[forbidden]; ok {
+			t.Fatalf("patch unexpectedly included %q: %#v", forbidden, patchPayload)
+		}
+	}
+
+	var state haproxyBackendModel
+	diags := resp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.Balance.ValueString() != "leastconn" || state.ServerTimeout.ValueInt64() != 45000 || state.AgentPort.ValueString() != "2200" {
+		t.Fatalf("state not refreshed from API: %#v", state)
+	}
+}
+
+func TestHaproxyBackendResourceUpdateSkipsPatchWithoutChanges(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		if r.Method != http.MethodGet || r.URL.RequestURI() != "/api/v2/services/haproxy/backends?name=app_backend" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":42,"name":"app_backend","balance":"roundrobin"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	backendResource := &haproxyBackendResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendResourceSchema(t)
+	model := nullHaproxyBackendModel()
+	model.ID = types.StringValue("app_backend")
+	model.Name = types.StringValue("app_backend")
+	model.Balance = types.StringValue("roundrobin")
+
+	resp := resource.UpdateResponse{
+		State: testResourceState(t, schema, model),
+	}
+	backendResource.Update(context.Background(), resource.UpdateRequest{
+		Plan:  testResourcePlan(t, schema, model),
+		State: testResourceState(t, schema, model),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/backends?name=app_backend",
+		"GET /api/v2/services/haproxy/backends?name=app_backend",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+}
+
+func TestHaproxyBackendResourceDeleteResolvesAPIID(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v2/services/haproxy/backends":
+			if got := r.URL.Query().Get("name"); got != "app_backend" {
+				t.Fatalf("backend lookup name = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":42,"name":"app_backend"}]}`))
+		case http.MethodDelete + " /api/v2/services/haproxy/backend":
+			if got := r.URL.Query().Get("id"); got != "42" {
+				t.Fatalf("delete id = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":null}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	backendResource := &haproxyBackendResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendResourceSchema(t)
+	stateModel := nullHaproxyBackendModel()
+	stateModel.ID = types.StringValue("app_backend")
+	stateModel.Name = types.StringValue("app_backend")
+
+	resp := resource.DeleteResponse{
+		State: testResourceState(t, schema, stateModel),
+	}
+	backendResource.Delete(context.Background(), resource.DeleteRequest{
+		State: testResourceState(t, schema, stateModel),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/backends?name=app_backend",
+		"DELETE /api/v2/services/haproxy/backend?id=42",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatalf("state was not removed")
+	}
+}
+
+func TestHaproxyBackendResourceImportUsesNaturalName(t *testing.T) {
+	t.Parallel()
+
+	backendResource := &haproxyBackendResource{}
+	schema := haproxyBackendResourceSchema(t)
+
+	validResp := resource.ImportStateResponse{
+		State: tfsdk.State{Schema: schema},
+	}
+	backendResource.ImportState(context.Background(), resource.ImportStateRequest{ID: "app_backend"}, &validResp)
+	if validResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", validResp.Diagnostics)
+	}
+	var state haproxyBackendModel
+	diags := validResp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.ID.ValueString() != "app_backend" || state.Name.ValueString() != "app_backend" {
+		t.Fatalf("imported state = %#v", state)
+	}
+
+	invalidResp := resource.ImportStateResponse{
+		State: tfsdk.State{Schema: schema},
+	}
+	backendResource.ImportState(context.Background(), resource.ImportStateRequest{ID: "   "}, &invalidResp)
+	if !invalidResp.Diagnostics.HasError() {
+		t.Fatalf("expected diagnostic for blank import id")
+	}
+}
+
+func TestHaproxyBackendSchemaIsConservative(t *testing.T) {
+	schema := haproxyBackendResourceSchema(t)
+	for _, forbidden := range []string{"servers", "acls", "actions", "errorfiles", "advanced", "advanced_backend", "stats_password"} {
+		if _, ok := schema.Attributes[forbidden]; ok {
+			t.Fatalf("resource schema should not expose %q before ownership is validated", forbidden)
+		}
+	}
+	if _, ok := schema.Attributes["name"]; !ok {
+		t.Fatalf("resource schema missing name")
+	}
+	if _, ok := schema.Attributes["agent_port"]; !ok {
+		t.Fatalf("resource schema missing agent_port")
+	}
+	if _, ok := schema.Attributes["persist_cookie_name"]; !ok {
+		t.Fatalf("resource schema missing persist_cookie_name")
+	}
+}
+
+func haproxyBackendResourceSchema(t *testing.T) resourceschema.Schema {
+	t.Helper()
+
+	var resp resource.SchemaResponse
+	(&haproxyBackendResource{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected resource schema diagnostics: %#v", resp.Diagnostics)
+	}
+
+	return resp.Schema
+}

--- a/internal/provider/haproxy_settings.go
+++ b/internal/provider/haproxy_settings.go
@@ -575,6 +575,10 @@ func apiBoolWithLabel(payload map[string]any, label string, names ...string) (ty
 }
 
 func apiInt64(payload map[string]any, names ...string) (types.Int64, error) {
+	return apiInt64WithLabel(payload, "HAProxy settings", names...)
+}
+
+func apiInt64WithLabel(payload map[string]any, label string, names ...string) (types.Int64, error) {
 	value, name, ok := apiValue(payload, names...)
 	if !ok || value == nil {
 		return types.Int64Null(), nil
@@ -583,13 +587,13 @@ func apiInt64(payload map[string]any, names ...string) (types.Int64, error) {
 	switch typed := value.(type) {
 	case float64:
 		if math.Trunc(typed) != typed {
-			return types.Int64Null(), fmt.Errorf("HAProxy settings field %q is %v, not an integer", name, typed)
+			return types.Int64Null(), fmt.Errorf("%s field %q is %v, not an integer", label, name, typed)
 		}
 		return types.Int64Value(int64(typed)), nil
 	case json.Number:
 		intValue, err := typed.Int64()
 		if err != nil {
-			return types.Int64Null(), fmt.Errorf("HAProxy settings field %q is %q, not an integer: %w", name, typed.String(), err)
+			return types.Int64Null(), fmt.Errorf("%s field %q is %q, not an integer: %w", label, name, typed.String(), err)
 		}
 		return types.Int64Value(intValue), nil
 	case string:
@@ -598,15 +602,19 @@ func apiInt64(payload map[string]any, names ...string) (types.Int64, error) {
 		}
 		intValue, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
 		if err != nil {
-			return types.Int64Null(), fmt.Errorf("HAProxy settings field %q is %q, not an integer: %w", name, typed, err)
+			return types.Int64Null(), fmt.Errorf("%s field %q is %q, not an integer: %w", label, name, typed, err)
 		}
 		return types.Int64Value(intValue), nil
 	default:
-		return types.Int64Null(), fmt.Errorf("HAProxy settings field %q has unsupported integer type %T", name, value)
+		return types.Int64Null(), fmt.Errorf("%s field %q has unsupported integer type %T", label, name, value)
 	}
 }
 
 func apiString(payload map[string]any, names ...string) (types.String, error) {
+	return apiStringWithLabel(payload, "HAProxy settings", names...)
+}
+
+func apiStringWithLabel(payload map[string]any, label string, names ...string) (types.String, error) {
 	value, name, ok := apiValue(payload, names...)
 	if !ok || value == nil {
 		return types.StringNull(), nil
@@ -614,7 +622,7 @@ func apiString(payload map[string]any, names ...string) (types.String, error) {
 
 	typed, ok := value.(string)
 	if !ok {
-		return types.StringNull(), fmt.Errorf("HAProxy settings field %q has unsupported string type %T", name, value)
+		return types.StringNull(), fmt.Errorf("%s field %q has unsupported string type %T", label, name, value)
 	}
 
 	return types.StringValue(typed), nil

--- a/internal/provider/haproxy_settings_test.go
+++ b/internal/provider/haproxy_settings_test.go
@@ -26,6 +26,9 @@ func TestProviderRegistersHaproxySettings(t *testing.T) {
 	if !resourceTypeRegistered(resources, "pfsense_haproxy_apply") {
 		t.Fatalf("pfsense_haproxy_apply resource was not registered")
 	}
+	if !resourceTypeRegistered(resources, "pfsense_haproxy_backend") {
+		t.Fatalf("pfsense_haproxy_backend resource was not registered")
+	}
 	if !resourceTypeRegistered(resources, "pfsense_haproxy_settings") {
 		t.Fatalf("pfsense_haproxy_settings resource was not registered")
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -119,6 +119,7 @@ func (p *haproxyProvider) Configure(ctx context.Context, req provider.ConfigureR
 func (p *haproxyProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		newHaproxyApplyResource,
+		newHaproxyBackendResource,
 		newHaproxySettingsResource,
 	}
 }


### PR DESCRIPTION
## Summary

Implements issue #8 / M3-01 by adding a conservative `pfsense_haproxy_backend` resource for top-level HAProxy backends.

- Adds backend CRUD and import using backend name as the Terraform natural key.
- Resolves the current pfSense object ID from `GET /services/haproxy/backends?name=...` before PATCH/DELETE because pfSense object IDs are treated as transient.
- Reuses the existing `pfsense.Client` response-envelope handling and process-level write guard through normal client methods.
- Keeps backend writes non-applying; docs and examples show explicit `pfsense_haproxy_apply` usage.
- Documents UAT-pending assumptions for backend lookup, object IDs, conditional fields, and no hidden apply behavior.

## Validation

- `terraform fmt -check examples`
- `make lint`
- `go test ./...`

## Limitations / UAT Pending

- Live UAT schema capture is still pending.
- The resource assumes plural backend reads return backend objects with `id` and `name` fields.
- The schema intentionally excludes nested servers, ACLs, actions, error files, stats, and advanced pass-through fields until child ownership and sensitivity are validated.
- Conditional pfREST fields such as `agent_port` and `persist_cookie_name` are exposed but assumed required only when their enabling booleans are true.

Closes #8.