### PR TITLE
Implement HAProxy backend server resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,11 +254,13 @@ resource "pfsense_haproxy_apply" "addressvalidator" {
     }))
     backend_servers = sha1(jsonencode({
       app01 = {
-        name    = pfsense_haproxy_backend_server.addressvalidator_01.name
-        address = pfsense_haproxy_backend_server.addressvalidator_01.address
-        port    = pfsense_haproxy_backend_server.addressvalidator_01.port
-        status  = pfsense_haproxy_backend_server.addressvalidator_01.status
-        weight  = pfsense_haproxy_backend_server.addressvalidator_01.weight
+        name            = pfsense_haproxy_backend_server.addressvalidator_01.name
+        address         = pfsense_haproxy_backend_server.addressvalidator_01.address
+        port            = pfsense_haproxy_backend_server.addressvalidator_01.port
+        status          = pfsense_haproxy_backend_server.addressvalidator_01.status
+        weight          = pfsense_haproxy_backend_server.addressvalidator_01.weight
+        ssl             = pfsense_haproxy_backend_server.addressvalidator_01.ssl
+        sslserververify = pfsense_haproxy_backend_server.addressvalidator_01.sslserververify
       }
     }))
   }

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Terraform provider for managing the pfSense HAProxy package through `pfSense-pkg
 
 Bootstrap scaffold is in place. `pfsense_haproxy_settings` is implemented with
 an import-first ownership model, `pfsense_haproxy_apply` provides an explicit
-apply/reload lifecycle, and `pfsense_haproxy_backend` manages top-level HAProxy
-backends by natural name. Additional HAProxy resources are tracked through
-GitHub issues and milestones.
+apply/reload lifecycle, `pfsense_haproxy_backend` manages top-level HAProxy
+backends by natural name, and `pfsense_haproxy_backend_server` manages backend
+server children by parent/backend name and server name. Additional HAProxy
+resources are tracked through GitHub issues and milestones.
 
 ## Requirements
 
@@ -154,6 +155,39 @@ UAT validation is still pending. The implementation assumes
 `HAProxyBackend` scalar field names, and backend writes do not apply pending
 HAProxy changes unless a separate `pfsense_haproxy_apply` resource is used.
 
+## HAProxy backend servers
+
+`resource "pfsense_haproxy_backend_server"` manages backend server children:
+
+- Create re-queries the parent backend by name, checks for an existing server
+  with `GET /services/haproxy/backend/servers?parent_id=...&name=...`, then
+  sends `POST /services/haproxy/backend/server`.
+- Read re-queries the parent backend by name and removes Terraform state if the
+  parent backend or child server no longer exists.
+- Update re-queries the parent backend and child server before sending
+  `PATCH /services/haproxy/backend/server` with the current `parent_id`, child
+  `id`, and changed scalar fields.
+- Delete re-queries the parent backend and child server before sending
+  `DELETE /services/haproxy/backend/server?parent_id=...&id=...`; if either is
+  already gone, Terraform state is removed.
+- Import uses `backend_name/server_name`, for example
+  `terraform import pfsense_haproxy_backend_server.app app_backend/app01`.
+- No HAProxy apply/reload is triggered by this resource.
+
+Terraform state uses `backend_name/server_name` as the stable ID because pfSense
+object IDs are implementation details and may change across config rewrites. The
+resource schema is intentionally conservative: it exposes `backend_name`,
+`name`, `address`, `port`, `status`, `weight`, `ssl`, `sslserververify`, and the
+read-only `serverid`. The `advanced` server field is deferred until the
+sensitivity and ownership model is validated on UAT.
+
+UAT validation is still pending. The implementation assumes
+`GET /services/haproxy/backend/servers?parent_id=...&name=...` returns backend
+server objects with `id`, `name`, `address`, and `port`; create/update/delete
+use the documented child `parent_id` contract; and backend server writes only
+mark HAProxy configuration pending until a separate `pfsense_haproxy_apply`
+resource is used.
+
 ## Development
 
 ```bash
@@ -168,11 +202,11 @@ make testacc
 
 - `pfsense_haproxy_apply`
 - `pfsense_haproxy_backend`
+- `pfsense_haproxy_backend_server`
 - `pfsense_haproxy_settings`
 
 ## Planned resources
 
-- `pfsense_haproxy_backend_server`
 - `pfsense_haproxy_frontend`
 - `pfsense_haproxy_frontend_address`
 - `pfsense_haproxy_frontend_acl`
@@ -195,8 +229,20 @@ resource "pfsense_haproxy_backend" "addressvalidator" {
   monitor_httpversion = "HTTP/1.1"
 }
 
+resource "pfsense_haproxy_backend_server" "addressvalidator_01" {
+  backend_name = pfsense_haproxy_backend.addressvalidator.name
+  name         = "addressvalidator_01"
+  address      = "10.30.10.21"
+  port         = 8080
+  status       = "active"
+  weight       = 10
+}
+
 resource "pfsense_haproxy_apply" "addressvalidator" {
-  depends_on = [pfsense_haproxy_backend.addressvalidator]
+  depends_on = [
+    pfsense_haproxy_backend.addressvalidator,
+    pfsense_haproxy_backend_server.addressvalidator_01,
+  ]
 
   triggers = {
     backend = sha1(jsonencode({
@@ -206,12 +252,21 @@ resource "pfsense_haproxy_apply" "addressvalidator" {
       monitor_uri    = pfsense_haproxy_backend.addressvalidator.monitor_uri
       server_timeout = pfsense_haproxy_backend.addressvalidator.server_timeout
     }))
+    backend_servers = sha1(jsonencode({
+      app01 = {
+        name    = pfsense_haproxy_backend_server.addressvalidator_01.name
+        address = pfsense_haproxy_backend_server.addressvalidator_01.address
+        port    = pfsense_haproxy_backend_server.addressvalidator_01.port
+        status  = pfsense_haproxy_backend_server.addressvalidator_01.status
+        weight  = pfsense_haproxy_backend_server.addressvalidator_01.weight
+      }
+    }))
   }
 }
 ```
 
-Backend server resources and remaining schemas will be finalized from approved
-UAT pfSense REST API endpoint responses before production use.
+Remaining schemas will be finalized from approved UAT pfSense REST API endpoint
+responses before production use.
 
 ## Schema inventory
 

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -88,6 +88,15 @@ For M3-01, `pfsense_haproxy_backend` uses the upstream `HAProxyBackend.inc`
 model as a conservative implementation reference. Terraform stores backend
 names as stable natural keys, resolves the current pfSense object ID from
 `GET /services/haproxy/backends?name=...` before update/delete, and manages only
-selected scalar fields. Nested backend servers, ACLs, actions, error files,
-stats, and advanced pass-through fields remain pending UAT confirmation and
-separate ownership decisions.
+selected scalar fields. Nested ACLs, actions, error files, stats, and advanced
+pass-through fields remain pending UAT confirmation and separate ownership
+decisions.
+
+For M3-02, `pfsense_haproxy_backend_server` uses the upstream
+`HAProxyBackendServer.inc` model as a conservative implementation reference.
+Terraform stores `backend_name/server_name` as a stable natural key, resolves the
+current parent backend ID before every child write, resolves the current child
+ID before update/delete, and manages only `address`, `port`, `status`, `weight`,
+`ssl`, and `sslserververify`. The read-only `serverid` field is exposed for
+drift visibility. The `advanced` server field remains pending UAT confirmation
+because it can contain arbitrary HAProxy server configuration.

--- a/docs/schema/haproxy-endpoint-inventory.md
+++ b/docs/schema/haproxy-endpoint-inventory.md
@@ -27,8 +27,8 @@ published documentation.
 | `/api/v2/services/haproxy/backend` | GET, POST, PATCH, DELETE | Singular | HAProxyBackend | pfSense-pkg-haproxy | Pending |
 | `/api/v2/services/haproxy/backend/error_file` | GET, POST, PATCH, DELETE | Singular | HAProxyBackendErrorFile | pfSense-pkg-haproxy | Pending |
 | `/api/v2/services/haproxy/backend/errorfiles` | GET, DELETE | Plural | HAProxyBackendErrorFile | pfSense-pkg-haproxy | Pending |
-| `/api/v2/services/haproxy/backend/server` | GET, POST, PATCH, DELETE | Singular | HAProxyBackendServer | pfSense-pkg-haproxy | Pending |
-| `/api/v2/services/haproxy/backend/servers` | GET, DELETE | Plural | HAProxyBackendServer | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/backend/server` | GET, POST, PATCH, DELETE | Singular | HAProxyBackendServer | pfSense-pkg-haproxy | Implemented in M3-02; UAT pending |
+| `/api/v2/services/haproxy/backend/servers` | GET, DELETE | Plural | HAProxyBackendServer | pfSense-pkg-haproxy | Implemented in M3-02; UAT pending |
 | `/api/v2/services/haproxy/backends` | GET, PUT, DELETE | Plural | HAProxyBackend | pfSense-pkg-haproxy | Pending |
 | `/api/v2/services/haproxy/file` | GET, POST, PATCH, DELETE | Singular | HAProxyFile | pfSense-pkg-haproxy | Pending |
 | `/api/v2/services/haproxy/files` | GET, PUT, DELETE | Plural | HAProxyFile | pfSense-pkg-haproxy | Pending |

--- a/docs/schema/resource-schema-decisions.md
+++ b/docs/schema/resource-schema-decisions.md
@@ -40,7 +40,7 @@ Primary references:
 |--------------------|-----------|-------------------|--------------------------------|----------|
 | `pfsense_haproxy_settings` | HAProxySettings | `GET/PATCH /api/v2/services/haproxy/settings` | Settings patch body is partial; no create/delete. | Implemented as split model in M2-01: data source reads settings; resource is singleton import-first with fixed ID `settings`, create blocked, update PATCH only, delete state-only, no apply/reload. |
 | `pfsense_haproxy_backend` | HAProxyBackend | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend`; `GET /backends` | Create requires `name`; public OpenAPI also marks conditional `agent_port` and `persist_cookie_name` as required when agent checks or cookie persistence are enabled. Patch requires `id`. | Implemented in M3-01 as a durable top-level resource using backend `name` as Terraform's stable natural key. Before update/delete, resolve pfSense's current object ID from `GET /backends?name=...`. Manage selected scalar fields only; keep embedded servers, ACLs, actions, error files, stats, and advanced pass-through fields out of scope pending UAT ownership confirmation. |
-| `pfsense_haproxy_backend_server` | HAProxyBackendServer | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/server` | Create requires `parent_id`, `name`, `address`, `port`. Patch requires `parent_id`, `id`. | Child resource under backend. Terraform ID must retain backend API ID and server API ID. |
+| `pfsense_haproxy_backend_server` | HAProxyBackendServer | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/server`; `GET /backend/servers` | Create requires `parent_id`, `name`, `address`, `port`. Patch requires `parent_id`, `id`. | Implemented in M3-02 as a backend child resource using `backend_name/server_name` as Terraform's stable natural key. Before create/update/delete, resolve the current parent backend ID by backend name; before update/delete, resolve the current child ID by server name under that parent. Manage only `address`, `port`, `status`, `weight`, `ssl`, and `sslserververify`; expose read-only `serverid`; defer `advanced` until UAT validates sensitivity and ownership. |
 | `pfsense_haproxy_backend_acl` | HAProxyBackendACL | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/acl` | Create requires `parent_id`, `name`, `expression`, `value`. Patch requires `parent_id`, `id`. | Child resource under backend. |
 | `pfsense_haproxy_backend_action` | HAProxyBackendAction | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/action` | Create requires `parent_id` plus action-specific fields in the public schema. | Child resource under backend. Conditional fields need UAT examples before strict Terraform validation. |
 | `pfsense_haproxy_backend_error_file` | HAProxyBackendErrorFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/error_file` | Create requires `parent_id`, `errorcode`, `errorfile`. | Child resource under backend. Consider later if required for managed routes. |
@@ -75,6 +75,9 @@ Primary references:
 - Confirm `GET /api/v2/services/haproxy/backends?name=...` returns exact-name
   matches or, at minimum, a list containing `id` and `name` fields that can be
   filtered client-side.
+- Confirm `GET /api/v2/services/haproxy/backend/servers?parent_id=...&name=...`
+  returns exact-name child matches or, at minimum, a list containing `id`,
+  `name`, `address`, and `port` fields that can be filtered client-side.
 - Whether published conditional fields such as `agent_port` and
   `persist_cookie_name` are required only when their enabling booleans are true
   on UAT.

--- a/examples/haproxy_backend.tf
+++ b/examples/haproxy_backend.tf
@@ -11,14 +11,28 @@ resource "pfsense_haproxy_backend" "app" {
   monitor_httpversion = "HTTP/1.1"
 }
 
+resource "pfsense_haproxy_backend_server" "app01" {
+  backend_name = pfsense_haproxy_backend.app.name
+  name         = "app01"
+  address      = "10.30.10.21"
+  port         = 8080
+  status       = "active"
+  weight       = 10
+}
+
 # Explicit apply after backend changes. There is intentionally no hidden
-# auto-apply in pfsense_haproxy_backend or other durable HAProxy resources.
+# auto-apply in pfsense_haproxy_backend, pfsense_haproxy_backend_server, or
+# other durable HAProxy resources.
 #
 # UAT note: this assumes GET /services/haproxy/backends returns objects with
 # stable names and transient pfSense IDs, and that POST/PATCH/DELETE backend
 # writes only mark HAProxy configuration pending until pfsense_haproxy_apply runs.
+# Backend server writes additionally assume child lookups by parent_id and name.
 resource "pfsense_haproxy_apply" "app_backend" {
-  depends_on = [pfsense_haproxy_backend.app]
+  depends_on = [
+    pfsense_haproxy_backend.app,
+    pfsense_haproxy_backend_server.app01,
+  ]
 
   triggers = {
     backend = sha1(jsonencode({
@@ -32,6 +46,15 @@ resource "pfsense_haproxy_apply" "app_backend" {
       httpcheck_method    = pfsense_haproxy_backend.app.httpcheck_method
       monitor_uri         = pfsense_haproxy_backend.app.monitor_uri
       monitor_httpversion = pfsense_haproxy_backend.app.monitor_httpversion
+    }))
+    backend_servers = sha1(jsonencode({
+      app01 = {
+        name    = pfsense_haproxy_backend_server.app01.name
+        address = pfsense_haproxy_backend_server.app01.address
+        port    = pfsense_haproxy_backend_server.app01.port
+        status  = pfsense_haproxy_backend_server.app01.status
+        weight  = pfsense_haproxy_backend_server.app01.weight
+      }
     }))
   }
 

--- a/examples/haproxy_backend.tf
+++ b/examples/haproxy_backend.tf
@@ -49,11 +49,13 @@ resource "pfsense_haproxy_apply" "app_backend" {
     }))
     backend_servers = sha1(jsonencode({
       app01 = {
-        name    = pfsense_haproxy_backend_server.app01.name
-        address = pfsense_haproxy_backend_server.app01.address
-        port    = pfsense_haproxy_backend_server.app01.port
-        status  = pfsense_haproxy_backend_server.app01.status
-        weight  = pfsense_haproxy_backend_server.app01.weight
+        name            = pfsense_haproxy_backend_server.app01.name
+        address         = pfsense_haproxy_backend_server.app01.address
+        port            = pfsense_haproxy_backend_server.app01.port
+        status          = pfsense_haproxy_backend_server.app01.status
+        weight          = pfsense_haproxy_backend_server.app01.weight
+        ssl             = pfsense_haproxy_backend_server.app01.ssl
+        sslserververify = pfsense_haproxy_backend_server.app01.sslserververify
       }
     }))
   }

--- a/internal/provider/haproxy_backend_server.go
+++ b/internal/provider/haproxy_backend_server.go
@@ -1,0 +1,772 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	haproxyBackendServerPath  = "/services/haproxy/backend/server"
+	haproxyBackendServersPath = "/services/haproxy/backend/servers"
+)
+
+var (
+	_ resource.Resource                = (*haproxyBackendServerResource)(nil)
+	_ resource.ResourceWithConfigure   = (*haproxyBackendServerResource)(nil)
+	_ resource.ResourceWithImportState = (*haproxyBackendServerResource)(nil)
+
+	haproxyNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+)
+
+type backendServerAttributeKind string
+
+const (
+	backendServerAttributeBool   backendServerAttributeKind = "bool"
+	backendServerAttributeInt64  backendServerAttributeKind = "int64"
+	backendServerAttributeString backendServerAttributeKind = "string"
+)
+
+type backendServerAttribute struct {
+	Name        string
+	JSONName    string
+	Kind        backendServerAttributeKind
+	Description string
+}
+
+var haproxyBackendServerAttributes = []backendServerAttribute{
+	{Name: "address", JSONName: "address", Kind: backendServerAttributeString, Description: "Hostname or IP address for this backend server. Hostnames are resolved by HAProxy at service startup."},
+	{Name: "port", JSONName: "port", Kind: backendServerAttributeInt64, Description: "TCP port to forward to on this backend server."},
+	{Name: "status", JSONName: "status", Kind: backendServerAttributeString, Description: "Eligibility status for this backend server: active, backup, disabled, or inactive."},
+	{Name: "weight", JSONName: "weight", Kind: backendServerAttributeInt64, Description: "Load-balancing weight for this backend server. pfREST accepts values from 0 through 256."},
+	{Name: "ssl", JSONName: "ssl", Kind: backendServerAttributeBool, Description: "Use SSL/TLS when forwarding to this backend server."},
+	{Name: "sslserververify", JSONName: "sslserververify", Kind: backendServerAttributeBool, Description: "Verify the backend server SSL/TLS certificate when forwarding with SSL/TLS."},
+}
+
+type haproxyBackendServerResource struct {
+	client *pfsense.Client
+}
+
+type haproxyBackendServerModel struct {
+	ID              types.String `tfsdk:"id"`
+	BackendName     types.String `tfsdk:"backend_name"`
+	Name            types.String `tfsdk:"name"`
+	Address         types.String `tfsdk:"address"`
+	Port            types.Int64  `tfsdk:"port"`
+	Status          types.String `tfsdk:"status"`
+	Weight          types.Int64  `tfsdk:"weight"`
+	SSL             types.Bool   `tfsdk:"ssl"`
+	SSLServerVerify types.Bool   `tfsdk:"sslserververify"`
+	ServerID        types.Int64  `tfsdk:"serverid"`
+}
+
+func newHaproxyBackendServerResource() resource.Resource {
+	return &haproxyBackendServerResource{}
+}
+
+func (r *haproxyBackendServerResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "pfsense_haproxy_backend_server"
+}
+
+func (r *haproxyBackendServerResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resourceschema.Schema{
+		Description: "Manages a pfSense HAProxy backend server as a child of a pfsense_haproxy_backend. Terraform uses backend name plus server name as the stable ID and resolves pfSense's current backend/server object IDs before writes because pfSense object IDs may not be durable.",
+		Attributes:  haproxyBackendServerResourceSchemaAttributes(),
+	}
+}
+
+func (r *haproxyBackendServerResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*pfsense.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected resource configure type", fmt.Sprintf("Expected *pfsense.Client, got %T.", req.ProviderData))
+		return
+	}
+
+	r.client = client
+}
+
+func (r *haproxyBackendServerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before creating pfsense_haproxy_backend_server.")
+		return
+	}
+
+	var plan haproxyBackendServerModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	normalized, err := validateHaproxyBackendServerPlan(plan)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend server", err.Error())
+		return
+	}
+
+	_, parentID, found, err := findHaproxyBackendByName(ctx, r.client, normalized.backendName)
+	if err != nil {
+		resp.Diagnostics.AddError("Find parent HAProxy backend before create failed", backendLookupErrorDetail(normalized.backendName, err))
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError("Create HAProxy backend server failed", fmt.Sprintf("Parent backend %q was not found on pfSense. Create or import pfsense_haproxy_backend.%s before managing child servers.", normalized.backendName, normalized.backendName))
+		return
+	}
+
+	_, _, found, err = findHaproxyBackendServerByName(ctx, r.client, parentID, normalized.backendName, normalized.name)
+	if err != nil {
+		resp.Diagnostics.AddError("Check existing HAProxy backend server failed", backendServerLookupErrorDetail(normalized.backendName, normalized.name, err))
+		return
+	}
+	if found {
+		resp.Diagnostics.AddError(
+			"HAProxy backend server already exists",
+			fmt.Sprintf("A pfSense HAProxy backend server named %q already exists under backend %q. Import it with `terraform import pfsense_haproxy_backend_server.<name> %s` before managing it.", normalized.name, normalized.backendName, haproxyBackendServerTerraformID(normalized.backendName, normalized.name)),
+		)
+		return
+	}
+
+	if err := r.client.Post(ctx, haproxyBackendServerPath, buildHaproxyBackendServerCreatePayload(plan, parentID, normalized), nil); err != nil {
+		resp.Diagnostics.AddError("Create HAProxy backend server failed", err.Error())
+		return
+	}
+
+	server, _, found, err := findHaproxyBackendServerByName(ctx, r.client, parentID, normalized.backendName, normalized.name)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy backend server after create failed", backendServerLookupErrorDetail(normalized.backendName, normalized.name, err))
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError(
+			"Read HAProxy backend server after create failed",
+			fmt.Sprintf("Created server %q under backend %q but GET %s did not return it. Confirm the live UAT child response shape and natural-key filtering before relying on this resource.", normalized.name, normalized.backendName, haproxyBackendServersPath),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, server)...)
+}
+
+func (r *haproxyBackendServerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before reading pfsense_haproxy_backend_server.")
+		return
+	}
+
+	var state haproxyBackendServerModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keys, err := haproxyBackendServerStateKeys(state)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend server state", err.Error())
+		return
+	}
+
+	_, parentID, found, err := findHaproxyBackendByName(ctx, r.client, keys.backendName)
+	if err != nil {
+		resp.Diagnostics.AddError("Find parent HAProxy backend failed", backendLookupErrorDetail(keys.backendName, err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	server, _, found, err := findHaproxyBackendServerByName(ctx, r.client, parentID, keys.backendName, keys.name)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy backend server failed", backendServerLookupErrorDetail(keys.backendName, keys.name, err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, server)...)
+}
+
+func (r *haproxyBackendServerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before updating pfsense_haproxy_backend_server.")
+		return
+	}
+
+	var plan, prior haproxyBackendServerModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	normalized, err := validateHaproxyBackendServerPlan(plan)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend server", err.Error())
+		return
+	}
+	priorKeys, err := haproxyBackendServerStateKeys(prior)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend server prior state", err.Error())
+		return
+	}
+	if normalized.backendName != priorKeys.backendName || normalized.name != priorKeys.name {
+		resp.Diagnostics.AddError("Renaming HAProxy backend servers is not supported", "The backend name and server name form the Terraform natural key. Change either value by creating a new resource and deleting the old one.")
+		return
+	}
+
+	_, parentID, found, err := findHaproxyBackendByName(ctx, r.client, normalized.backendName)
+	if err != nil {
+		resp.Diagnostics.AddError("Find parent HAProxy backend before update failed", backendLookupErrorDetail(normalized.backendName, err))
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError("Update HAProxy backend server failed", fmt.Sprintf("Parent backend %q was not found on pfSense. Recreate it or remove the child server from Terraform state.", normalized.backendName))
+		return
+	}
+
+	_, serverID, found, err := findHaproxyBackendServerByName(ctx, r.client, parentID, normalized.backendName, normalized.name)
+	if err != nil {
+		resp.Diagnostics.AddError("Find HAProxy backend server before update failed", backendServerLookupErrorDetail(normalized.backendName, normalized.name, err))
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError("Update HAProxy backend server failed", fmt.Sprintf("Server %q under backend %q was not found on pfSense. Recreate it or remove it from Terraform state.", normalized.name, normalized.backendName))
+		return
+	}
+
+	patch := buildHaproxyBackendServerPatch(plan, prior, parentID, serverID)
+	if len(patch) > 2 {
+		if err := r.client.Patch(ctx, haproxyBackendServerPath, patch, nil); err != nil {
+			resp.Diagnostics.AddError("Update HAProxy backend server failed", err.Error())
+			return
+		}
+	}
+
+	server, _, found, err := findHaproxyBackendServerByName(ctx, r.client, parentID, normalized.backendName, normalized.name)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy backend server after update failed", backendServerLookupErrorDetail(normalized.backendName, normalized.name, err))
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError("Read HAProxy backend server after update failed", fmt.Sprintf("Server %q under backend %q was not returned by GET %s after PATCH.", normalized.name, normalized.backendName, haproxyBackendServersPath))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, server)...)
+}
+
+func (r *haproxyBackendServerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before deleting pfsense_haproxy_backend_server.")
+		return
+	}
+
+	var state haproxyBackendServerModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keys, err := haproxyBackendServerStateKeys(state)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend server state", err.Error())
+		return
+	}
+
+	_, parentID, found, err := findHaproxyBackendByName(ctx, r.client, keys.backendName)
+	if err != nil {
+		resp.Diagnostics.AddError("Find parent HAProxy backend before delete failed", backendLookupErrorDetail(keys.backendName, err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	_, serverID, found, err := findHaproxyBackendServerByName(ctx, r.client, parentID, keys.backendName, keys.name)
+	if err != nil {
+		resp.Diagnostics.AddError("Find HAProxy backend server before delete failed", backendServerLookupErrorDetail(keys.backendName, keys.name, err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if err := r.client.Delete(ctx, haproxyBackendServerDeletePath(parentID, serverID), nil); err != nil {
+		resp.Diagnostics.AddError("Delete HAProxy backend server failed", err.Error())
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *haproxyBackendServerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	keys, err := parseHaproxyBackendServerImportID(req.ID)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy backend server import ID", err.Error())
+		return
+	}
+
+	model := nullHaproxyBackendServerModel()
+	model.ID = types.StringValue(haproxyBackendServerTerraformID(keys.backendName, keys.name))
+	model.BackendName = types.StringValue(keys.backendName)
+	model.Name = types.StringValue(keys.name)
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func haproxyBackendServerResourceSchemaAttributes() map[string]resourceschema.Attribute {
+	return map[string]resourceschema.Attribute{
+		"id": resourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Stable Terraform ID for the backend server in backend_name/name form. This is not the pfSense object ID.",
+		},
+		"backend_name": resourceschema.StringAttribute{
+			Required:    true,
+			Description: "Name of the parent pfsense_haproxy_backend. Terraform resolves the current pfSense backend object ID by this natural key before every backend server write.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"name": resourceschema.StringAttribute{
+			Required:    true,
+			Description: "Unique HAProxy backend server name within the parent backend. pfSense restricts names to letters, numbers, dot, hyphen, and underscore. Terraform treats this as part of the natural key and requires replacement if it changes.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"address": resourceschema.StringAttribute{
+			Required:    true,
+			Description: "Hostname or IP address for this backend server. Hostnames are resolved by HAProxy at service startup.",
+		},
+		"port": resourceschema.Int64Attribute{
+			Required:    true,
+			Description: "TCP port to forward to on this backend server.",
+		},
+		"status": resourceschema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Eligibility status for this backend server: active, backup, disabled, or inactive.",
+		},
+		"weight": resourceschema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Load-balancing weight for this backend server. pfREST accepts values from 0 through 256.",
+		},
+		"ssl": resourceschema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Use SSL/TLS when forwarding to this backend server.",
+		},
+		"sslserververify": resourceschema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Verify the backend server SSL/TLS certificate when forwarding with SSL/TLS.",
+		},
+		"serverid": resourceschema.Int64Attribute{
+			Computed:    true,
+			Description: "Read-only HAProxy backend server ID assigned by pfSense for internal use.",
+		},
+	}
+}
+
+type haproxyBackendServerKeys struct {
+	backendName string
+	name        string
+	address     string
+	port        int64
+}
+
+func validateHaproxyBackendServerPlan(model haproxyBackendServerModel) (haproxyBackendServerKeys, error) {
+	backendName, err := haproxyBackendServerBackendName(model.BackendName)
+	if err != nil {
+		return haproxyBackendServerKeys{}, err
+	}
+	name, err := haproxyBackendServerName(model.Name)
+	if err != nil {
+		return haproxyBackendServerKeys{}, err
+	}
+	address, err := haproxyBackendServerAddress(model.Address)
+	if err != nil {
+		return haproxyBackendServerKeys{}, err
+	}
+	port, err := haproxyBackendServerPort(model.Port)
+	if err != nil {
+		return haproxyBackendServerKeys{}, err
+	}
+	if err := validateHaproxyBackendServerOptionalFields(model); err != nil {
+		return haproxyBackendServerKeys{}, err
+	}
+
+	return haproxyBackendServerKeys{
+		backendName: backendName,
+		name:        name,
+		address:     address,
+		port:        port,
+	}, nil
+}
+
+func validateHaproxyBackendServerOptionalFields(model haproxyBackendServerModel) error {
+	if !model.Status.IsNull() && !model.Status.IsUnknown() {
+		switch model.Status.ValueString() {
+		case "active", "backup", "disabled", "inactive":
+		default:
+			return fmt.Errorf("status must be one of active, backup, disabled, or inactive")
+		}
+	}
+	if !model.Weight.IsNull() && !model.Weight.IsUnknown() {
+		weight := model.Weight.ValueInt64()
+		if weight < 0 || weight > 256 {
+			return fmt.Errorf("weight must be between 0 and 256")
+		}
+	}
+
+	return nil
+}
+
+func haproxyBackendServerBackendName(value types.String) (string, error) {
+	name, err := haproxyBackendName(value)
+	if err != nil {
+		return "", fmt.Errorf("backend_name %s", err.Error())
+	}
+	if !haproxyNamePattern.MatchString(name) {
+		return "", fmt.Errorf("backend_name may contain only letters, numbers, dot, hyphen, and underscore")
+	}
+
+	return name, nil
+}
+
+func haproxyBackendServerName(value types.String) (string, error) {
+	if value.IsNull() || value.IsUnknown() {
+		return "", fmt.Errorf("name is required")
+	}
+	name := value.ValueString()
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "", fmt.Errorf("name must not be empty")
+	}
+	if trimmed != name {
+		return "", fmt.Errorf("name must not contain leading or trailing whitespace")
+	}
+	if len(name) < 2 {
+		return "", fmt.Errorf("name must be at least 2 characters")
+	}
+	if !haproxyNamePattern.MatchString(name) {
+		return "", fmt.Errorf("name may contain only letters, numbers, dot, hyphen, and underscore")
+	}
+
+	return name, nil
+}
+
+func haproxyBackendServerAddress(value types.String) (string, error) {
+	if value.IsNull() || value.IsUnknown() {
+		return "", fmt.Errorf("address is required")
+	}
+	address := value.ValueString()
+	trimmed := strings.TrimSpace(address)
+	if trimmed == "" {
+		return "", fmt.Errorf("address must not be empty")
+	}
+	if trimmed != address {
+		return "", fmt.Errorf("address must not contain leading or trailing whitespace")
+	}
+
+	return address, nil
+}
+
+func haproxyBackendServerPort(value types.Int64) (int64, error) {
+	if value.IsNull() || value.IsUnknown() {
+		return 0, fmt.Errorf("port is required")
+	}
+	port := value.ValueInt64()
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("port must be between 1 and 65535")
+	}
+
+	return port, nil
+}
+
+func haproxyBackendServerStateKeys(model haproxyBackendServerModel) (haproxyBackendServerKeys, error) {
+	if !model.BackendName.IsNull() && !model.BackendName.IsUnknown() && !model.Name.IsNull() && !model.Name.IsUnknown() {
+		backendName, err := haproxyBackendServerBackendName(model.BackendName)
+		if err != nil {
+			return haproxyBackendServerKeys{}, err
+		}
+		name, err := haproxyBackendServerName(model.Name)
+		if err != nil {
+			return haproxyBackendServerKeys{}, err
+		}
+		return haproxyBackendServerKeys{backendName: backendName, name: name}, nil
+	}
+	if !model.ID.IsNull() && !model.ID.IsUnknown() {
+		return parseHaproxyBackendServerImportID(model.ID.ValueString())
+	}
+
+	return haproxyBackendServerKeys{}, fmt.Errorf("state is missing backend_name and name")
+}
+
+func parseHaproxyBackendServerImportID(id string) (haproxyBackendServerKeys, error) {
+	trimmed := strings.TrimSpace(id)
+	backendName, serverName, ok := strings.Cut(trimmed, "/")
+	if !ok || backendName == "" || serverName == "" || strings.Contains(serverName, "/") {
+		return haproxyBackendServerKeys{}, fmt.Errorf("import pfsense_haproxy_backend_server with ID backend_name/server_name")
+	}
+
+	backend, err := haproxyBackendServerBackendName(types.StringValue(backendName))
+	if err != nil {
+		return haproxyBackendServerKeys{}, err
+	}
+	server, err := haproxyBackendServerName(types.StringValue(serverName))
+	if err != nil {
+		return haproxyBackendServerKeys{}, err
+	}
+
+	return haproxyBackendServerKeys{backendName: backend, name: server}, nil
+}
+
+func buildHaproxyBackendServerCreatePayload(plan haproxyBackendServerModel, parentID string, normalized haproxyBackendServerKeys) map[string]any {
+	payload := map[string]any{
+		"parent_id": parentID,
+		"name":      normalized.name,
+		"address":   normalized.address,
+		"port":      normalized.port,
+	}
+	values := plan.attrValues()
+
+	for _, attribute := range haproxyBackendServerAttributes {
+		if attribute.Name == "address" || attribute.Name == "port" {
+			continue
+		}
+		planned := values[attribute.Name]
+		if planned.IsNull() || planned.IsUnknown() {
+			continue
+		}
+		payload[attribute.JSONName] = backendServerTerraformValueToJSON(attribute.Kind, planned)
+	}
+
+	return payload
+}
+
+func buildHaproxyBackendServerPatch(plan haproxyBackendServerModel, prior haproxyBackendServerModel, parentID string, serverID string) map[string]any {
+	patch := map[string]any{
+		"parent_id": parentID,
+		"id":        serverID,
+	}
+	planValues := plan.attrValues()
+	priorValues := prior.attrValues()
+
+	for _, attribute := range haproxyBackendServerAttributes {
+		planned := planValues[attribute.Name]
+		if planned.IsUnknown() {
+			continue
+		}
+		if planned.Equal(priorValues[attribute.Name]) {
+			continue
+		}
+
+		patch[attribute.JSONName] = backendServerTerraformValueToJSON(attribute.Kind, planned)
+	}
+
+	return patch
+}
+
+func findHaproxyBackendServerByName(ctx context.Context, client *pfsense.Client, parentID string, backendName string, name string) (haproxyBackendServerModel, string, bool, error) {
+	var raw any
+	if err := client.Get(ctx, haproxyBackendServersQueryPath(parentID, name), &raw); err != nil {
+		return haproxyBackendServerModel{}, "", false, err
+	}
+
+	payloads, err := haproxyBackendServerPayloadList(raw)
+	if err != nil {
+		return haproxyBackendServerModel{}, "", false, err
+	}
+
+	var matched map[string]any
+	for _, payload := range payloads {
+		candidateName, err := apiRequiredStringWithLabel(payload, "HAProxy backend server", "name")
+		if err != nil {
+			return haproxyBackendServerModel{}, "", false, err
+		}
+		if candidateName != name {
+			continue
+		}
+		if matched != nil {
+			return haproxyBackendServerModel{}, "", false, fmt.Errorf("multiple HAProxy backend servers named %q were returned under backend %q; server names must be unique within a backend for Terraform natural-key management", name, backendName)
+		}
+		matched = payload
+	}
+
+	if matched == nil {
+		return haproxyBackendServerModel{}, "", false, nil
+	}
+
+	apiID, err := apiRequiredScalarStringWithLabel(matched, "HAProxy backend server", "id")
+	if err != nil {
+		return haproxyBackendServerModel{}, "", false, fmt.Errorf("%w; confirm UAT returns child object IDs from GET %s before using update/delete", err, haproxyBackendServersPath)
+	}
+	model, err := haproxyBackendServerModelFromAPI(matched, backendName)
+	if err != nil {
+		return haproxyBackendServerModel{}, "", false, err
+	}
+
+	return model, apiID, true, nil
+}
+
+func haproxyBackendServerPayloadList(raw any) ([]map[string]any, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	switch typed := raw.(type) {
+	case []any:
+		payloads := make([]map[string]any, 0, len(typed))
+		for index, item := range typed {
+			payload, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("HAProxy backend servers response item %d has unsupported type %T", index, item)
+			}
+			payloads = append(payloads, payload)
+		}
+		return payloads, nil
+	case []map[string]any:
+		return typed, nil
+	case map[string]any:
+		return []map[string]any{typed}, nil
+	default:
+		return nil, fmt.Errorf("HAProxy backend servers response has unsupported type %T; confirm the live UAT /services/haproxy/backend/servers schema", raw)
+	}
+}
+
+func haproxyBackendServerModelFromAPI(payload map[string]any, backendName string) (haproxyBackendServerModel, error) {
+	server := nullHaproxyBackendServerModel()
+
+	name, err := apiRequiredStringWithLabel(payload, "HAProxy backend server", "name")
+	if err != nil {
+		return server, err
+	}
+	address, err := apiRequiredStringWithLabel(payload, "HAProxy backend server", "address")
+	if err != nil {
+		return server, err
+	}
+	port, err := apiRequiredInt64WithLabel(payload, "HAProxy backend server", "port")
+	if err != nil {
+		return server, err
+	}
+
+	server.ID = types.StringValue(haproxyBackendServerTerraformID(backendName, name))
+	server.BackendName = types.StringValue(backendName)
+	server.Name = types.StringValue(name)
+	server.Address = types.StringValue(address)
+	server.Port = types.Int64Value(port)
+
+	if server.Status, err = apiStringWithLabel(payload, "HAProxy backend server", "status"); err != nil {
+		return server, err
+	}
+	if server.Weight, err = apiInt64WithLabel(payload, "HAProxy backend server", "weight"); err != nil {
+		return server, err
+	}
+	if server.SSL, err = apiBoolWithLabel(payload, "HAProxy backend server", "ssl"); err != nil {
+		return server, err
+	}
+	if server.SSLServerVerify, err = apiBoolWithLabel(payload, "HAProxy backend server", "sslserververify"); err != nil {
+		return server, err
+	}
+	if server.ServerID, err = apiInt64WithLabel(payload, "HAProxy backend server", "serverid"); err != nil {
+		return server, err
+	}
+
+	return server, nil
+}
+
+func apiRequiredInt64WithLabel(payload map[string]any, label string, names ...string) (int64, error) {
+	value, err := apiInt64WithLabel(payload, label, names...)
+	if err != nil {
+		return 0, err
+	}
+	if value.IsNull() || value.IsUnknown() {
+		return 0, fmt.Errorf("%s response did not include required integer field %q", label, names[0])
+	}
+
+	return value.ValueInt64(), nil
+}
+
+func nullHaproxyBackendServerModel() haproxyBackendServerModel {
+	return haproxyBackendServerModel{
+		ID:              types.StringNull(),
+		BackendName:     types.StringNull(),
+		Name:            types.StringNull(),
+		Address:         types.StringNull(),
+		Port:            types.Int64Null(),
+		Status:          types.StringNull(),
+		Weight:          types.Int64Null(),
+		SSL:             types.BoolNull(),
+		SSLServerVerify: types.BoolNull(),
+		ServerID:        types.Int64Null(),
+	}
+}
+
+func (m haproxyBackendServerModel) attrValues() map[string]attr.Value {
+	return map[string]attr.Value{
+		"address":         m.Address,
+		"port":            m.Port,
+		"status":          m.Status,
+		"weight":          m.Weight,
+		"ssl":             m.SSL,
+		"sslserververify": m.SSLServerVerify,
+	}
+}
+
+func backendServerTerraformValueToJSON(kind backendServerAttributeKind, value attr.Value) any {
+	if value.IsNull() {
+		return nil
+	}
+
+	switch kind {
+	case backendServerAttributeBool:
+		return value.(types.Bool).ValueBool()
+	case backendServerAttributeInt64:
+		return value.(types.Int64).ValueInt64()
+	case backendServerAttributeString:
+		return value.(types.String).ValueString()
+	default:
+		return nil
+	}
+}
+
+func haproxyBackendServersQueryPath(parentID string, name string) string {
+	values := url.Values{}
+	values.Set("parent_id", parentID)
+	values.Set("name", name)
+	return haproxyBackendServersPath + "?" + values.Encode()
+}
+
+func haproxyBackendServerDeletePath(parentID string, serverID string) string {
+	values := url.Values{}
+	values.Set("parent_id", parentID)
+	values.Set("id", serverID)
+	return haproxyBackendServerPath + "?" + values.Encode()
+}
+
+func haproxyBackendServerTerraformID(backendName string, name string) string {
+	return backendName + "/" + name
+}
+
+func backendServerLookupErrorDetail(backendName string, name string, err error) string {
+	return fmt.Sprintf("%s. Confirm GET %s is available on UAT, accepts parent_id/name query filters, returns server objects with stable name fields, and includes the transient pfSense child object id required for update/delete. Backend name: %q. Server name: %q.", err.Error(), haproxyBackendServersPath, backendName, name)
+}

--- a/internal/provider/haproxy_backend_server_test.go
+++ b/internal/provider/haproxy_backend_server_test.go
@@ -1,0 +1,558 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestHaproxyBackendServerResourceCreateUsesParentLookupAndDoesNotApply(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	var postPayload map[string]any
+	serverLookupCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v2/services/haproxy/backends":
+			if got := r.URL.Query().Get("name"); got != "app_backend" {
+				t.Fatalf("backend lookup name = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":42,"name":"app_backend"}]}`))
+		case http.MethodGet + " /api/v2/services/haproxy/backend/servers":
+			if got := r.URL.Query().Get("parent_id"); got != "42" {
+				t.Fatalf("server lookup parent_id = %q", got)
+			}
+			if got := r.URL.Query().Get("name"); got != "app01" {
+				t.Fatalf("server lookup name = %q", got)
+			}
+			serverLookupCount++
+			if serverLookupCount == 1 {
+				_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{
+				"code": 200,
+				"status": "ok",
+				"data": [{
+					"id": 7,
+					"name": "app01",
+					"address": "10.0.0.10",
+					"port": "8080",
+					"status": "active",
+					"weight": "10",
+					"ssl": "yes",
+					"sslserververify": false,
+					"serverid": 123
+				}]
+			}`))
+		case http.MethodPost + " /api/v2/services/haproxy/backend/server":
+			if err := json.NewDecoder(r.Body).Decode(&postPayload); err != nil {
+				t.Fatalf("decode POST payload: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"id":7}}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	serverResource := &haproxyBackendServerResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendServerResourceSchema(t)
+	plan := nullHaproxyBackendServerModel()
+	plan.BackendName = types.StringValue("app_backend")
+	plan.Name = types.StringValue("app01")
+	plan.Address = types.StringValue("10.0.0.10")
+	plan.Port = types.Int64Value(8080)
+	plan.Status = types.StringValue("active")
+	plan.Weight = types.Int64Value(10)
+	plan.SSL = types.BoolValue(true)
+	plan.SSLServerVerify = types.BoolValue(false)
+
+	resp := resource.CreateResponse{
+		State: testResourceState(t, schema, plan),
+	}
+	serverResource.Create(context.Background(), resource.CreateRequest{
+		Plan: testResourcePlan(t, schema, plan),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/backends?name=app_backend",
+		"GET /api/v2/services/haproxy/backend/servers?name=app01&parent_id=42",
+		"POST /api/v2/services/haproxy/backend/server",
+		"GET /api/v2/services/haproxy/backend/servers?name=app01&parent_id=42",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+
+	if postPayload["parent_id"] != "42" {
+		t.Fatalf("POST parent_id = %#v", postPayload["parent_id"])
+	}
+	if postPayload["name"] != "app01" || postPayload["address"] != "10.0.0.10" {
+		t.Fatalf("POST natural fields = %#v", postPayload)
+	}
+	if postPayload["port"] != float64(8080) {
+		t.Fatalf("POST port = %#v", postPayload["port"])
+	}
+	if postPayload["ssl"] != true {
+		t.Fatalf("POST ssl = %#v", postPayload["ssl"])
+	}
+	for _, forbidden := range []string{"id", "apply", "async", "serverid", "advanced"} {
+		if _, ok := postPayload[forbidden]; ok {
+			t.Fatalf("POST unexpectedly included %q: %#v", forbidden, postPayload)
+		}
+	}
+
+	var state haproxyBackendServerModel
+	diags := resp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.ID.ValueString() != "app_backend/app01" || state.BackendName.ValueString() != "app_backend" || state.Name.ValueString() != "app01" {
+		t.Fatalf("natural key not preserved in state: %#v", state)
+	}
+	if state.Port.ValueInt64() != 8080 || !state.SSL.ValueBool() || state.ServerID.ValueInt64() != 123 {
+		t.Fatalf("state was not refreshed from API defaults: %#v", state)
+	}
+}
+
+func TestHaproxyBackendServerResourceReadRemovesWhenParentMissing(t *testing.T) {
+	t.Parallel()
+
+	var requests []string
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		if r.Method != http.MethodGet || r.URL.RequestURI() != "/api/v2/services/haproxy/backends?name=missing_backend" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	serverResource := &haproxyBackendServerResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendServerResourceSchema(t)
+	stateModel := nullHaproxyBackendServerModel()
+	stateModel.ID = types.StringValue("missing_backend/app01")
+	stateModel.BackendName = types.StringValue("missing_backend")
+	stateModel.Name = types.StringValue("app01")
+
+	resp := resource.ReadResponse{
+		State: testResourceState(t, schema, stateModel),
+	}
+	serverResource.Read(context.Background(), resource.ReadRequest{
+		State: testResourceState(t, schema, stateModel),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatalf("missing parent backend did not remove child state")
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{"GET /api/v2/services/haproxy/backends?name=missing_backend"}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+}
+
+func TestHaproxyBackendServerResourceUpdateRequeriesParentAndPatchesChangedFieldsOnly(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	var patchPayload map[string]any
+	serverLookupCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v2/services/haproxy/backends":
+			if got := r.URL.Query().Get("name"); got != "app_backend" {
+				t.Fatalf("backend lookup name = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":99,"name":"app_backend"}]}`))
+		case http.MethodGet + " /api/v2/services/haproxy/backend/servers":
+			if got := r.URL.Query().Get("parent_id"); got != "99" {
+				t.Fatalf("server lookup parent_id = %q", got)
+			}
+			if got := r.URL.Query().Get("name"); got != "app01" {
+				t.Fatalf("server lookup name = %q", got)
+			}
+			serverLookupCount++
+			address := "10.0.0.10"
+			weight := "10"
+			if serverLookupCount > 1 {
+				address = "10.0.0.11"
+				weight = "20"
+			}
+			_, _ = w.Write([]byte(`{
+				"code": 200,
+				"status": "ok",
+				"data": [{
+					"id": "7",
+					"name": "app01",
+					"address": "` + address + `",
+					"port": 8080,
+					"status": "backup",
+					"weight": "` + weight + `",
+					"ssl": true,
+					"sslserververify": "yes",
+					"serverid": "123"
+				}]
+			}`))
+		case http.MethodPatch + " /api/v2/services/haproxy/backend/server":
+			if err := json.NewDecoder(r.Body).Decode(&patchPayload); err != nil {
+				t.Fatalf("decode PATCH payload: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":null}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	serverResource := &haproxyBackendServerResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendServerResourceSchema(t)
+
+	prior := nullHaproxyBackendServerModel()
+	prior.ID = types.StringValue("app_backend/app01")
+	prior.BackendName = types.StringValue("app_backend")
+	prior.Name = types.StringValue("app01")
+	prior.Address = types.StringValue("10.0.0.10")
+	prior.Port = types.Int64Value(8080)
+	prior.Status = types.StringValue("active")
+	prior.Weight = types.Int64Value(10)
+	prior.SSL = types.BoolValue(false)
+	prior.SSLServerVerify = types.BoolValue(false)
+	prior.ServerID = types.Int64Value(123)
+
+	plan := prior
+	plan.Address = types.StringValue("10.0.0.11")
+	plan.Status = types.StringValue("backup")
+	plan.Weight = types.Int64Value(20)
+	plan.SSL = types.BoolValue(true)
+	plan.SSLServerVerify = types.BoolValue(true)
+
+	resp := resource.UpdateResponse{
+		State: testResourceState(t, schema, prior),
+	}
+	serverResource.Update(context.Background(), resource.UpdateRequest{
+		Plan:  testResourcePlan(t, schema, plan),
+		State: testResourceState(t, schema, prior),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/backends?name=app_backend",
+		"GET /api/v2/services/haproxy/backend/servers?name=app01&parent_id=99",
+		"PATCH /api/v2/services/haproxy/backend/server",
+		"GET /api/v2/services/haproxy/backend/servers?name=app01&parent_id=99",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+
+	if patchPayload["parent_id"] != "99" || patchPayload["id"] != "7" {
+		t.Fatalf("patch IDs = %#v", patchPayload)
+	}
+	if patchPayload["address"] != "10.0.0.11" || patchPayload["status"] != "backup" {
+		t.Fatalf("patch scalar fields = %#v", patchPayload)
+	}
+	if patchPayload["weight"] != float64(20) || patchPayload["ssl"] != true || patchPayload["sslserververify"] != true {
+		t.Fatalf("patch bool/int fields = %#v", patchPayload)
+	}
+	for _, forbidden := range []string{"name", "backend_name", "apply", "async", "serverid", "advanced", "port"} {
+		if _, ok := patchPayload[forbidden]; ok {
+			t.Fatalf("patch unexpectedly included %q: %#v", forbidden, patchPayload)
+		}
+	}
+
+	var state haproxyBackendServerModel
+	diags := resp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.Address.ValueString() != "10.0.0.11" || state.Status.ValueString() != "backup" || state.Weight.ValueInt64() != 20 {
+		t.Fatalf("state not refreshed from API: %#v", state)
+	}
+}
+
+func TestHaproxyBackendServerResourceUpdateErrorsWhenParentMissing(t *testing.T) {
+	t.Parallel()
+
+	var requests []string
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		if r.Method != http.MethodGet || r.URL.RequestURI() != "/api/v2/services/haproxy/backends?name=missing_backend" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	serverResource := &haproxyBackendServerResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendServerResourceSchema(t)
+	prior := nullHaproxyBackendServerModel()
+	prior.ID = types.StringValue("missing_backend/app01")
+	prior.BackendName = types.StringValue("missing_backend")
+	prior.Name = types.StringValue("app01")
+	prior.Address = types.StringValue("10.0.0.10")
+	prior.Port = types.Int64Value(8080)
+	plan := prior
+	plan.Address = types.StringValue("10.0.0.11")
+
+	var resp resource.UpdateResponse
+	resp.State = testResourceState(t, schema, prior)
+	serverResource.Update(context.Background(), resource.UpdateRequest{
+		Plan:  testResourcePlan(t, schema, plan),
+		State: testResourceState(t, schema, prior),
+	}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected missing parent diagnostic")
+	}
+	if !strings.Contains(diagnosticsText(resp.Diagnostics), "Parent backend") {
+		t.Fatalf("diagnostics did not describe missing parent: %s", diagnosticsText(resp.Diagnostics))
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{"GET /api/v2/services/haproxy/backends?name=missing_backend"}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+}
+
+func TestHaproxyBackendServerResourceDeleteResolvesCurrentParentAndServerIDs(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v2/services/haproxy/backends":
+			if got := r.URL.Query().Get("name"); got != "app_backend" {
+				t.Fatalf("backend lookup name = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":99,"name":"app_backend"}]}`))
+		case http.MethodGet + " /api/v2/services/haproxy/backend/servers":
+			if got := r.URL.Query().Get("parent_id"); got != "99" {
+				t.Fatalf("server lookup parent_id = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":7,"name":"app01","address":"10.0.0.10","port":8080}]}`))
+		case http.MethodDelete + " /api/v2/services/haproxy/backend/server":
+			if got := r.URL.Query().Get("parent_id"); got != "99" {
+				t.Fatalf("delete parent_id = %q", got)
+			}
+			if got := r.URL.Query().Get("id"); got != "7" {
+				t.Fatalf("delete id = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":null}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	serverResource := &haproxyBackendServerResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendServerResourceSchema(t)
+	stateModel := nullHaproxyBackendServerModel()
+	stateModel.ID = types.StringValue("app_backend/app01")
+	stateModel.BackendName = types.StringValue("app_backend")
+	stateModel.Name = types.StringValue("app01")
+
+	resp := resource.DeleteResponse{
+		State: testResourceState(t, schema, stateModel),
+	}
+	serverResource.Delete(context.Background(), resource.DeleteRequest{
+		State: testResourceState(t, schema, stateModel),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/backends?name=app_backend",
+		"GET /api/v2/services/haproxy/backend/servers?name=app01&parent_id=99",
+		"DELETE /api/v2/services/haproxy/backend/server?id=7&parent_id=99",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatalf("state was not removed")
+	}
+}
+
+func TestHaproxyBackendServerResourceDeleteRemovesStateWhenParentAlreadyMissing(t *testing.T) {
+	t.Parallel()
+
+	var requests []string
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		if r.Method != http.MethodGet || r.URL.RequestURI() != "/api/v2/services/haproxy/backends?name=missing_backend" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	serverResource := &haproxyBackendServerResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyBackendServerResourceSchema(t)
+	stateModel := nullHaproxyBackendServerModel()
+	stateModel.ID = types.StringValue("missing_backend/app01")
+	stateModel.BackendName = types.StringValue("missing_backend")
+	stateModel.Name = types.StringValue("app01")
+
+	resp := resource.DeleteResponse{
+		State: testResourceState(t, schema, stateModel),
+	}
+	serverResource.Delete(context.Background(), resource.DeleteRequest{
+		State: testResourceState(t, schema, stateModel),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatalf("state was not removed")
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{"GET /api/v2/services/haproxy/backends?name=missing_backend"}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+}
+
+func TestHaproxyBackendServerResourceImportUsesBackendAndServerNaturalNames(t *testing.T) {
+	t.Parallel()
+
+	serverResource := &haproxyBackendServerResource{}
+	schema := haproxyBackendServerResourceSchema(t)
+
+	validResp := resource.ImportStateResponse{
+		State: tfsdk.State{Schema: schema},
+	}
+	serverResource.ImportState(context.Background(), resource.ImportStateRequest{ID: "app_backend/app01"}, &validResp)
+	if validResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", validResp.Diagnostics)
+	}
+	var state haproxyBackendServerModel
+	diags := validResp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.ID.ValueString() != "app_backend/app01" || state.BackendName.ValueString() != "app_backend" || state.Name.ValueString() != "app01" {
+		t.Fatalf("imported state = %#v", state)
+	}
+
+	for _, id := range []string{"", "app_backend", "app_backend/", "/app01", "app_backend/app01/extra", "app_backend/a"} {
+		invalidResp := resource.ImportStateResponse{
+			State: tfsdk.State{Schema: schema},
+		}
+		serverResource.ImportState(context.Background(), resource.ImportStateRequest{ID: id}, &invalidResp)
+		if !invalidResp.Diagnostics.HasError() {
+			t.Fatalf("expected diagnostic for import id %q", id)
+		}
+	}
+}
+
+func TestHaproxyBackendServerSchemaIsConservative(t *testing.T) {
+	schema := haproxyBackendServerResourceSchema(t)
+	for _, required := range []string{"backend_name", "name", "address", "port"} {
+		if _, ok := schema.Attributes[required]; !ok {
+			t.Fatalf("resource schema missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{"advanced", "apply", "async", "parent_id", "server_id", "stats_password"} {
+		if _, ok := schema.Attributes[forbidden]; ok {
+			t.Fatalf("resource schema should not expose %q before ownership is validated", forbidden)
+		}
+	}
+}
+
+func haproxyBackendServerResourceSchema(t *testing.T) resourceschema.Schema {
+	t.Helper()
+
+	var resp resource.SchemaResponse
+	(&haproxyBackendServerResource{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected resource schema diagnostics: %#v", resp.Diagnostics)
+	}
+
+	return resp.Schema
+}

--- a/internal/provider/haproxy_settings_test.go
+++ b/internal/provider/haproxy_settings_test.go
@@ -29,6 +29,9 @@ func TestProviderRegistersHaproxySettings(t *testing.T) {
 	if !resourceTypeRegistered(resources, "pfsense_haproxy_backend") {
 		t.Fatalf("pfsense_haproxy_backend resource was not registered")
 	}
+	if !resourceTypeRegistered(resources, "pfsense_haproxy_backend_server") {
+		t.Fatalf("pfsense_haproxy_backend_server resource was not registered")
+	}
 	if !resourceTypeRegistered(resources, "pfsense_haproxy_settings") {
 		t.Fatalf("pfsense_haproxy_settings resource was not registered")
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -120,6 +120,7 @@ func (p *haproxyProvider) Resources(_ context.Context) []func() resource.Resourc
 	return []func() resource.Resource{
 		newHaproxyApplyResource,
 		newHaproxyBackendResource,
+		newHaproxyBackendServerResource,
 		newHaproxySettingsResource,
 	}
 }


### PR DESCRIPTION
## Summary

Implements issue #9 / M3-02 for `pfsense_haproxy_backend_server` as a conservative child resource under `pfsense_haproxy_backend`.

- Adds backend server CRUD/import using `backend_name/server_name` as Terraform's stable natural key.
- Re-queries the parent backend before child writes and resolves current pfSense parent/server IDs before mutations.
- Keeps HAProxy reload explicit through `pfsense_haproxy_apply`; no hidden apply behavior is added.
- Adds deterministic mock tests for create, read parent deletion, update order/missing parent, delete order/missing parent, import, and schema boundaries.
- Updates README, schema docs, and the backend example with explicit apply triggers covering backend servers.

Fixes #9.

## Validation

- `terraform fmt -recursive`
- `terraform fmt -check -recursive`
- `go test ./...`
- `make lint`
- `git diff --check`

## Notes

UAT acceptance was not run in this environment. The implementation remains gated by the documented UAT assumptions for `GET /services/haproxy/backend/servers?parent_id=...&name=...` response shape and child ID behavior.