### PR TITLE
Implement HAProxy frontend certificate resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ server children by parent/backend name and server name.
 `pfsense_haproxy_frontend` manages top-level HAProxy frontends by natural name,
 and `pfsense_haproxy_frontend_address` manages frontend bind/listen address
 children by parent/frontend name, listen address, custom address, and port.
+`pfsense_haproxy_frontend_certificate` attaches existing pfSense certificate
+references to frontends without managing certificate or private key material.
 Backend and backend server lookup data sources are available for read-only
 references to existing HAProxy objects. Additional HAProxy resources are tracked
 through GitHub issues and milestones.
@@ -224,10 +226,11 @@ Terraform state uses the frontend name as the stable ID because pfSense object
 IDs are implementation details and may not be durable across config rewrites.
 The resource schema is intentionally conservative: it exposes required `name`
 and `type` plus selected scalar fields for basic HTTP/TCP frontend lifecycle.
-Only `http` and `tcp` are supported for `type`; `https` is deferred until
-certificate ownership is modeled. Addresses, ACLs, actions, certificates, error
-files, `advanced`, `advanced_bind`, and default certificate ownership remain out
-of scope.
+Only `http` and `tcp` are supported for `type`; any separate `https` frontend
+mode remains deferred until UAT confirms how it interacts with frontend address
+SSL offload and certificate attachments. Addresses, ACLs, actions, error files,
+`advanced`, `advanced_bind`, and default certificate ownership remain out of
+scope for this top-level frontend resource.
 
 UAT validation is still pending. The implementation assumes
 `GET /services/haproxy/frontends?name=...` returns frontend objects with `id`,
@@ -270,6 +273,39 @@ returns frontend address objects with `id`, `extaddr`, `extaddr_custom`, and
 contract; and frontend address writes only mark HAProxy configuration pending
 until a separate `pfsense_haproxy_apply` resource is used.
 
+## HAProxy frontend certificates
+
+`resource "pfsense_haproxy_frontend_certificate"` attaches existing pfSense
+certificate references to frontend objects:
+
+- Create re-queries the parent frontend by name, checks for an existing
+  certificate attachment with
+  `GET /services/haproxy/frontend/certificates?parent_id=...&ssl_certificate=...`,
+  then sends `POST /services/haproxy/frontend/certificate`.
+- Read re-queries the parent frontend by name and removes Terraform state if
+  the parent frontend or child certificate attachment no longer exists.
+- Update is intentionally unsupported. `frontend_name` and `ssl_certificate`
+  both require replacement.
+- Delete re-queries the parent frontend and child certificate before sending
+  `DELETE /services/haproxy/frontend/certificate?parent_id=...&id=...`; if
+  either is already gone, Terraform state is removed.
+- Import uses `frontend_name/ssl_certificate`, for example
+  `terraform import pfsense_haproxy_frontend_certificate.app app_frontend/existing_cert_ref`.
+- No HAProxy apply/reload is triggered by this resource.
+
+Terraform state uses `frontend_name/ssl_certificate` as the stable ID because
+pfSense object IDs are implementation details and may change across config
+rewrites. The schema accepts only an existing certificate reference/name. It
+does not expose certificate bodies, private keys, PEM content, advanced fields,
+placement controls, or transient REST IDs.
+
+UAT validation is still pending. The implementation assumes
+`GET /services/haproxy/frontend/certificates?parent_id=...&ssl_certificate=...`
+returns certificate attachment objects with `id` and `ssl_certificate`;
+create/delete use the documented child `parent_id` contract; and certificate
+attachment writes only mark HAProxy configuration pending until a separate
+`pfsense_haproxy_apply` resource is used.
+
 ## Development
 
 ```bash
@@ -287,6 +323,7 @@ make testacc
 - `pfsense_haproxy_backend_server`
 - `pfsense_haproxy_frontend`
 - `pfsense_haproxy_frontend_address`
+- `pfsense_haproxy_frontend_certificate`
 - `pfsense_haproxy_settings`
 
 ## Data Sources
@@ -300,7 +337,6 @@ make testacc
 
 - `pfsense_haproxy_frontend_acl`
 - `pfsense_haproxy_frontend_action`
-- `pfsense_haproxy_frontend_certificate`
 - `pfsense_haproxy_file`
 
 ## Example ingress contract
@@ -346,12 +382,18 @@ resource "pfsense_haproxy_frontend_address" "addressvalidator_https" {
   extaddr_ssl    = true
 }
 
+resource "pfsense_haproxy_frontend_certificate" "addressvalidator_https" {
+  frontend_name   = pfsense_haproxy_frontend.addressvalidator.name
+  ssl_certificate = "existing_uat_certificate_ref"
+}
+
 resource "pfsense_haproxy_apply" "addressvalidator" {
   depends_on = [
     pfsense_haproxy_backend.addressvalidator,
     pfsense_haproxy_backend_server.addressvalidator_01,
     pfsense_haproxy_frontend.addressvalidator,
     pfsense_haproxy_frontend_address.addressvalidator_https,
+    pfsense_haproxy_frontend_certificate.addressvalidator_https,
   ]
 
   triggers = {
@@ -388,6 +430,11 @@ resource "pfsense_haproxy_apply" "addressvalidator" {
         extaddr_custom = pfsense_haproxy_frontend_address.addressvalidator_https.extaddr_custom
         extaddr_port   = pfsense_haproxy_frontend_address.addressvalidator_https.extaddr_port
         extaddr_ssl    = pfsense_haproxy_frontend_address.addressvalidator_https.extaddr_ssl
+      }
+    }))
+    frontend_certificates = sha1(jsonencode({
+      https = {
+        ssl_certificate = pfsense_haproxy_frontend_certificate.addressvalidator_https.ssl_certificate
       }
     }))
   }

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -113,9 +113,10 @@ For M4-01, `pfsense_haproxy_frontend` uses the upstream
 Terraform stores frontend names as stable natural keys, resolves the current
 pfSense object ID from `GET /services/haproxy/frontends?name=...` before
 update/delete, and manages only selected HTTP/TCP scalar fields. Addresses,
-ACLs, actions, certificates, error files, `advanced`, `advanced_bind`, and
-default certificate ownership remain pending UAT confirmation and separate
-ownership decisions.
+ACLs, actions, error files, `advanced`, `advanced_bind`, and default
+certificate ownership remain pending UAT confirmation and separate ownership
+decisions. Frontend certificate attachments are modeled separately by
+`pfsense_haproxy_frontend_certificate`.
 
 For M4-02, `pfsense_haproxy_frontend_address` uses the upstream
 `HAProxyFrontendAddress.inc` model as a conservative implementation reference.
@@ -125,3 +126,12 @@ write, resolves the current child ID before update/delete, and manages only
 `extaddr`, `extaddr_custom`, `extaddr_port`, and `extaddr_ssl`. The
 `exaddr_advanced` address field and placement/order controls remain pending UAT
 confirmation.
+
+For M4-03, `pfsense_haproxy_frontend_certificate` uses the upstream
+`HAProxyFrontendCertificate.inc` model as a conservative implementation
+reference. Terraform stores `frontend_name/ssl_certificate` as a stable natural
+key, resolves the current parent frontend ID before every child write, resolves
+the current child ID before delete, and manages only the existing
+`ssl_certificate` reference. The resource intentionally does not expose
+certificate bodies, private key material, PEM content, placement controls,
+advanced fields, or a PATCH update path.

--- a/docs/schema/haproxy-endpoint-inventory.md
+++ b/docs/schema/haproxy-endpoint-inventory.md
@@ -38,8 +38,8 @@ published documentation.
 | `/api/v2/services/haproxy/frontend/actions` | GET, DELETE | Plural | HAProxyFrontendAction | pfSense-pkg-haproxy | Pending |
 | `/api/v2/services/haproxy/frontend/address` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendAddress | pfSense-pkg-haproxy | Implemented in M4-02 for POST/PATCH/DELETE; UAT pending |
 | `/api/v2/services/haproxy/frontend/addresses` | GET, DELETE | Plural | HAProxyFrontendAddress | pfSense-pkg-haproxy | Implemented in M4-02 for GET lookup only; plural DELETE intentionally unused; UAT pending |
-| `/api/v2/services/haproxy/frontend/certificate` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendCertificate | pfSense-pkg-haproxy | Pending |
-| `/api/v2/services/haproxy/frontend/certificates` | GET, DELETE | Plural | HAProxyFrontendCertificate | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/frontend/certificate` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendCertificate | pfSense-pkg-haproxy | Implemented in M4-03 for POST/DELETE; PATCH intentionally unused; UAT pending |
+| `/api/v2/services/haproxy/frontend/certificates` | GET, DELETE | Plural | HAProxyFrontendCertificate | pfSense-pkg-haproxy | Implemented in M4-03 for GET lookup only; plural DELETE intentionally unused; UAT pending |
 | `/api/v2/services/haproxy/frontend` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontend | pfSense-pkg-haproxy | Implemented in M4-01; UAT pending |
 | `/api/v2/services/haproxy/frontend/error_file` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendErrorFile | pfSense-pkg-haproxy | Pending |
 | `/api/v2/services/haproxy/frontend/error_files` | GET, DELETE | Plural | HAProxyFrontendErrorFile | pfSense-pkg-haproxy | Pending |

--- a/docs/schema/resource-schema-decisions.md
+++ b/docs/schema/resource-schema-decisions.md
@@ -18,9 +18,9 @@ Primary references:
   deletes.
 - Treat child operations as parent-addressed API calls. Published OpenAPI
   documents `parent_id` plus child `id` for child reads, patches, and deletes.
-- Model Terraform resource IDs to preserve both parent and child API IDs for
-  child resources. The exact serialized ID format remains pending UAT response
-  confirmation.
+- Model Terraform resource IDs from stable natural keys. Resolve transient
+  parent and child API IDs from plural lookup endpoints immediately before
+  writes and deletes.
 - Do not use plural `PUT` replace-all endpoints or plural query `DELETE`
   endpoints for normal single-resource lifecycle operations.
 - HAProxy write endpoints do not apply pending service changes immediately in
@@ -30,9 +30,9 @@ Primary references:
   source. Do not add auto-apply flags to settings or durable resources unless a
   later issue intentionally changes that contract.
 - Mark actual secret-bearing attributes as sensitive when implemented. Public
-  schema names include `stats_password`, `HAProxyFile.content`, certificate
-  references, and custom/advanced HAProxy text fields that may carry private
-  material.
+  schema names include `stats_password`, `HAProxyFile.content`, certificate or
+  private-key bodies, and custom/advanced HAProxy text fields that may carry
+  private material.
 
 ## Resource Mapping
 
@@ -44,11 +44,11 @@ Primary references:
 | `pfsense_haproxy_backend_acl` | HAProxyBackendACL | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/acl` | Create requires `parent_id`, `name`, `expression`, `value`. Patch requires `parent_id`, `id`. | Child resource under backend. |
 | `pfsense_haproxy_backend_action` | HAProxyBackendAction | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/action` | Create requires `parent_id` plus action-specific fields in the public schema. | Child resource under backend. Conditional fields need UAT examples before strict Terraform validation. |
 | `pfsense_haproxy_backend_error_file` | HAProxyBackendErrorFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/backend/error_file` | Create requires `parent_id`, `errorcode`, `errorfile`. | Child resource under backend. Consider later if required for managed routes. |
-| `pfsense_haproxy_frontend` | HAProxyFrontend | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend`; `GET /frontends` | Create requires `name` and `type`. Patch requires `id`. | Implemented in M4-01 as a durable top-level resource using frontend `name` as Terraform's stable natural key. Before update/delete, resolve pfSense's current object ID from `GET /frontends?name=...`. Manage only `name`, `type`, and selected scalar fields: `descr`, `status`, `max_connections`, `backend_serverpool`, `socket_stats`, `dontlognull`, `dontlog_normal`, `log_separate_errors`, `log_detailed`, `client_timeout`, `forwardfor`, and `httpclose`. Support `http` and `tcp` only; defer `https` until certificate ownership is modeled. Keep addresses, ACLs, actions, certificates, error files, `advanced`, `advanced_bind`, and default certificate ownership out of scope pending UAT ownership confirmation. |
+| `pfsense_haproxy_frontend` | HAProxyFrontend | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend`; `GET /frontends` | Create requires `name` and `type`. Patch requires `id`. | Implemented in M4-01 as a durable top-level resource using frontend `name` as Terraform's stable natural key. Before update/delete, resolve pfSense's current object ID from `GET /frontends?name=...`. Manage only `name`, `type`, and selected scalar fields: `descr`, `status`, `max_connections`, `backend_serverpool`, `socket_stats`, `dontlognull`, `dontlog_normal`, `log_separate_errors`, `log_detailed`, `client_timeout`, `forwardfor`, and `httpclose`. Support `http` and `tcp` only; defer any separate `https` frontend type mode until UAT validates how it interacts with frontend address SSL offload and certificate attachments. Keep addresses, ACLs, actions, error files, `advanced`, `advanced_bind`, and default certificate ownership out of scope for this top-level resource. |
 | `pfsense_haproxy_frontend_address` | HAProxyFrontendAddress | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/address`; `GET /frontend/addresses` | Create requires `parent_id`, `extaddr`, `extaddr_custom`. Patch requires `parent_id`, `id`. | Implemented in M4-02 as a frontend child resource using `frontend_name/extaddr/extaddr_custom_or_-/extaddr_port` as Terraform's stable natural key. Before create/update/delete, resolve the current parent frontend ID by frontend name; before update/delete, resolve the current child ID by exact address fields under that parent. Manage only `extaddr`, `extaddr_custom`, `extaddr_port`, and `extaddr_ssl`; defer `exaddr_advanced` and placement until UAT validates sensitivity and ordering semantics. |
 | `pfsense_haproxy_frontend_acl` | HAProxyFrontendACL | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/acl` | Create requires `parent_id`, `name`, `expression`, `value`. Patch requires `parent_id`, `id`. | Child resource under frontend. |
 | `pfsense_haproxy_frontend_action` | HAProxyFrontendAction | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/action` | Create requires `parent_id` plus action-specific fields in the public schema. | Child resource under frontend. Conditional fields need UAT examples before strict Terraform validation. |
-| `pfsense_haproxy_frontend_certificate` | HAProxyFrontendCertificate | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/certificate` | Create requires `parent_id`; schema exposes `ssl_certificate`. | Child resource under frontend. Treat certificate identifiers as sensitive-adjacent and never capture certificate bodies. |
+| `pfsense_haproxy_frontend_certificate` | HAProxyFrontendCertificate | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/certificate`; `GET /frontend/certificates` | Create requires `parent_id`; schema exposes `ssl_certificate`. | Implemented in M4-03 as a frontend child resource using `frontend_name/ssl_certificate` as Terraform's stable natural key. Before create/delete, resolve the current parent frontend ID by frontend name; before delete, resolve the current child ID by exact certificate reference under that parent. Manage only existing `ssl_certificate` references; reject PEM/private-key-looking values; do not expose certificate bodies, private keys, placement, advanced fields, or a PATCH update path. |
 | `pfsense_haproxy_frontend_error_file` | HAProxyFrontendErrorFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/error_file` | Create requires `parent_id`, `errorcode`, `errorfile`. | Child resource under frontend. Consider later if required for managed routes. |
 | `pfsense_haproxy_file` | HAProxyFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/file`; `GET /files` | Create requires `name`, `content`. Patch requires `id`. | Defer until routes require managed HAProxy files. `content` must be sensitive in Terraform state and excluded from schema fixtures. |
 | `pfsense_haproxy_settings_dns_resolver` | HAProxyDNSResolver | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/settings/dns_resolver` | Create requires `name`, `server`. Patch requires `id`. | Model as settings child only if needed. Pending UAT confirmation of nesting and IDs. |
@@ -90,11 +90,18 @@ Primary references:
   whether `forwardfor` is rejected for TCP frontends server-side.
 - Confirm frontend address `placement` behavior before exposing any ordering
   control. The first implementation intentionally does not set placement.
+- Confirm `GET /api/v2/services/haproxy/frontend/certificates?parent_id=...&ssl_certificate=...`
+  returns exact frontend certificate attachment matches or, at minimum, a list
+  containing `id` and `ssl_certificate` fields that can be filtered
+  client-side.
+- Confirm whether frontend certificate attachments support ordering/placement
+  semantics on UAT. The first implementation intentionally does not set
+  placement and treats changes as replacement-only.
 - Whether published conditional fields such as `agent_port` and
   `persist_cookie_name` are required only when their enabling booleans are true
   on UAT.
 - Whether `https` frontend type should become a separate resource mode after
-  frontend certificate ownership is modeled.
+  frontend certificate attachment behavior is validated on UAT.
 - Whether conditional action fields can be omitted when unrelated to the chosen
   action.
 - Whether HAProxy and HAProxy-devel expose identical schema paths on this UAT

--- a/examples/haproxy_frontend.tf
+++ b/examples/haproxy_frontend.tf
@@ -22,20 +22,29 @@ resource "pfsense_haproxy_frontend_address" "app_https" {
   extaddr_ssl   = true
 }
 
+resource "pfsense_haproxy_frontend_certificate" "app_https" {
+  frontend_name   = pfsense_haproxy_frontend.app.name
+  ssl_certificate = "existing_uat_certificate_ref"
+}
+
 # Explicit apply after frontend changes. There is intentionally no hidden
-# auto-apply in pfsense_haproxy_frontend, pfsense_haproxy_frontend_address, or
-# other durable HAProxy resources.
+# auto-apply in pfsense_haproxy_frontend, pfsense_haproxy_frontend_address,
+# pfsense_haproxy_frontend_certificate, or other durable HAProxy resources.
 #
 # UAT note: this assumes GET /services/haproxy/frontends returns objects with
 # stable names and transient pfSense IDs, and that POST/PATCH/DELETE frontend
 # writes only mark HAProxy configuration pending until pfsense_haproxy_apply runs.
 # Frontend address writes additionally assume child lookups by parent_id,
-# extaddr, extaddr_custom, and extaddr_port.
+# extaddr, extaddr_custom, and extaddr_port. Frontend certificate writes assume
+# child lookups by parent_id and ssl_certificate. Replace
+# existing_uat_certificate_ref with an existing pfSense certificate reference;
+# do not place PEM certificate or private key material in Terraform.
 resource "pfsense_haproxy_apply" "app_frontend" {
   depends_on = [
     pfsense_haproxy_backend.app,
     pfsense_haproxy_frontend.app,
     pfsense_haproxy_frontend_address.app_https,
+    pfsense_haproxy_frontend_certificate.app_https,
   ]
 
   triggers = {
@@ -61,6 +70,11 @@ resource "pfsense_haproxy_apply" "app_frontend" {
         extaddr_custom = pfsense_haproxy_frontend_address.app_https.extaddr_custom
         extaddr_port   = pfsense_haproxy_frontend_address.app_https.extaddr_port
         extaddr_ssl    = pfsense_haproxy_frontend_address.app_https.extaddr_ssl
+      }
+    }))
+    frontend_certificates = sha1(jsonencode({
+      https = {
+        ssl_certificate = pfsense_haproxy_frontend_certificate.app_https.ssl_certificate
       }
     }))
   }

--- a/internal/provider/haproxy_frontend_certificate.go
+++ b/internal/provider/haproxy_frontend_certificate.go
@@ -12,6 +12,7 @@ import (
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -251,10 +252,37 @@ func haproxyFrontendCertificateResourceSchemaAttributes() map[string]resourcesch
 		"ssl_certificate": resourceschema.StringAttribute{
 			Required:    true,
 			Description: "Existing pfSense certificate reference to attach to the frontend. This must be a reference/name only, not PEM certificate or private key material. Terraform treats this as part of the natural key and requires replacement if it changes.",
+			Validators: []validator.String{
+				haproxyFrontendCertificateReferenceValidator{},
+			},
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},
 		},
+	}
+}
+
+type haproxyFrontendCertificateReferenceValidator struct{}
+
+func (v haproxyFrontendCertificateReferenceValidator) Description(context.Context) string {
+	return "value must be an existing pfSense certificate reference and cannot be certificate or private key material"
+}
+
+func (v haproxyFrontendCertificateReferenceValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v haproxyFrontendCertificateReferenceValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if _, err := haproxyFrontendCertificateSSLCertificate(req.ConfigValue); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid HAProxy frontend certificate reference",
+			err.Error(),
+		)
 	}
 }
 

--- a/internal/provider/haproxy_frontend_certificate.go
+++ b/internal/provider/haproxy_frontend_certificate.go
@@ -1,0 +1,504 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode"
+
+	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	haproxyFrontendCertificatePath  = "/services/haproxy/frontend/certificate"
+	haproxyFrontendCertificatesPath = "/services/haproxy/frontend/certificates"
+)
+
+var (
+	_ resource.Resource                = (*haproxyFrontendCertificateResource)(nil)
+	_ resource.ResourceWithConfigure   = (*haproxyFrontendCertificateResource)(nil)
+	_ resource.ResourceWithImportState = (*haproxyFrontendCertificateResource)(nil)
+)
+
+type haproxyFrontendCertificateResource struct {
+	client *pfsense.Client
+}
+
+type haproxyFrontendCertificateModel struct {
+	ID             types.String `tfsdk:"id"`
+	FrontendName   types.String `tfsdk:"frontend_name"`
+	SSLCertificate types.String `tfsdk:"ssl_certificate"`
+}
+
+func newHaproxyFrontendCertificateResource() resource.Resource {
+	return &haproxyFrontendCertificateResource{}
+}
+
+func (r *haproxyFrontendCertificateResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "pfsense_haproxy_frontend_certificate"
+}
+
+func (r *haproxyFrontendCertificateResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resourceschema.Schema{
+		Description: "Attaches an existing pfSense certificate reference to a pfsense_haproxy_frontend. Terraform stores only the frontend name and certificate reference as the stable ID and resolves pfSense's current frontend/certificate object IDs before writes because pfSense object IDs may not be durable.",
+		Attributes:  haproxyFrontendCertificateResourceSchemaAttributes(),
+	}
+}
+
+func (r *haproxyFrontendCertificateResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*pfsense.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected resource configure type", fmt.Sprintf("Expected *pfsense.Client, got %T.", req.ProviderData))
+		return
+	}
+
+	r.client = client
+}
+
+func (r *haproxyFrontendCertificateResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before creating pfsense_haproxy_frontend_certificate.")
+		return
+	}
+
+	var plan haproxyFrontendCertificateModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keys, err := validateHaproxyFrontendCertificatePlan(plan)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy frontend certificate", err.Error())
+		return
+	}
+
+	_, parentID, found, err := findHaproxyFrontendByName(ctx, r.client, keys.frontendName)
+	if err != nil {
+		resp.Diagnostics.AddError("Find parent HAProxy frontend before create failed", frontendCertificateParentLookupErrorDetail(keys.frontendName, err))
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError("Create HAProxy frontend certificate failed", fmt.Sprintf("Parent frontend %q was not found on pfSense. Create or import pfsense_haproxy_frontend.%s before managing child certificate attachments.", keys.frontendName, keys.frontendName))
+		return
+	}
+
+	_, _, found, err = findHaproxyFrontendCertificate(ctx, r.client, parentID, keys)
+	if err != nil {
+		resp.Diagnostics.AddError("Check existing HAProxy frontend certificate failed", frontendCertificateLookupErrorDetail(keys, err))
+		return
+	}
+	if found {
+		resp.Diagnostics.AddError(
+			"HAProxy frontend certificate already exists",
+			fmt.Sprintf("A pfSense HAProxy frontend certificate attachment for %q already exists under frontend %q. Import it with `terraform import pfsense_haproxy_frontend_certificate.<name> %s` before managing it.", keys.sslCertificate, keys.frontendName, haproxyFrontendCertificateTerraformID(keys)),
+		)
+		return
+	}
+
+	if err := r.client.Post(ctx, haproxyFrontendCertificatePath, buildHaproxyFrontendCertificateCreatePayload(parentID, keys), nil); err != nil {
+		resp.Diagnostics.AddError("Create HAProxy frontend certificate failed", err.Error())
+		return
+	}
+
+	certificate, _, found, err := findHaproxyFrontendCertificate(ctx, r.client, parentID, keys)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy frontend certificate after create failed", frontendCertificateLookupErrorDetail(keys, err))
+		return
+	}
+	if !found {
+		resp.Diagnostics.AddError(
+			"Read HAProxy frontend certificate after create failed",
+			fmt.Sprintf("Created certificate attachment %q under frontend %q but GET %s did not return it. Confirm the live UAT child response shape and natural-key filtering before relying on this resource.", keys.sslCertificate, keys.frontendName, haproxyFrontendCertificatesPath),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, certificate)...)
+}
+
+func (r *haproxyFrontendCertificateResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before reading pfsense_haproxy_frontend_certificate.")
+		return
+	}
+
+	var state haproxyFrontendCertificateModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keys, err := haproxyFrontendCertificateStateKeys(state)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy frontend certificate state", err.Error())
+		return
+	}
+
+	_, parentID, found, err := findHaproxyFrontendByName(ctx, r.client, keys.frontendName)
+	if err != nil {
+		resp.Diagnostics.AddError("Find parent HAProxy frontend failed", frontendCertificateParentLookupErrorDetail(keys.frontendName, err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	certificate, _, found, err := findHaproxyFrontendCertificate(ctx, r.client, parentID, keys)
+	if err != nil {
+		resp.Diagnostics.AddError("Read HAProxy frontend certificate failed", frontendCertificateLookupErrorDetail(keys, err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, certificate)...)
+}
+
+func (r *haproxyFrontendCertificateResource) Update(_ context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError(
+		"Updating HAProxy frontend certificates is not supported",
+		"frontend_name and ssl_certificate form the Terraform natural key and both require replacement. Create a new pfsense_haproxy_frontend_certificate resource and delete the old one instead of patching certificate attachments.",
+	)
+}
+
+func (r *haproxyFrontendCertificateResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("Missing pfSense client", "The provider was not configured before deleting pfsense_haproxy_frontend_certificate.")
+		return
+	}
+
+	var state haproxyFrontendCertificateModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keys, err := haproxyFrontendCertificateStateKeys(state)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy frontend certificate state", err.Error())
+		return
+	}
+
+	_, parentID, found, err := findHaproxyFrontendByName(ctx, r.client, keys.frontendName)
+	if err != nil {
+		resp.Diagnostics.AddError("Find parent HAProxy frontend before delete failed", frontendCertificateParentLookupErrorDetail(keys.frontendName, err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	_, certificateID, found, err := findHaproxyFrontendCertificate(ctx, r.client, parentID, keys)
+	if err != nil {
+		resp.Diagnostics.AddError("Find HAProxy frontend certificate before delete failed", frontendCertificateLookupErrorDetail(keys, err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if err := r.client.Delete(ctx, haproxyFrontendCertificateDeletePath(parentID, certificateID), nil); err != nil {
+		resp.Diagnostics.AddError("Delete HAProxy frontend certificate failed", err.Error())
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *haproxyFrontendCertificateResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	keys, err := parseHaproxyFrontendCertificateImportID(req.ID)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid HAProxy frontend certificate import ID", err.Error())
+		return
+	}
+
+	model := nullHaproxyFrontendCertificateModel()
+	model.ID = types.StringValue(haproxyFrontendCertificateTerraformID(keys))
+	model.FrontendName = types.StringValue(keys.frontendName)
+	model.SSLCertificate = types.StringValue(keys.sslCertificate)
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func haproxyFrontendCertificateResourceSchemaAttributes() map[string]resourceschema.Attribute {
+	return map[string]resourceschema.Attribute{
+		"id": resourceschema.StringAttribute{
+			Computed:    true,
+			Description: "Stable Terraform ID for the frontend certificate attachment in frontend_name/ssl_certificate form. This is not the pfSense child object ID.",
+		},
+		"frontend_name": resourceschema.StringAttribute{
+			Required:    true,
+			Description: "Name of the parent pfsense_haproxy_frontend. Terraform resolves the current pfSense frontend object ID by this natural key before every frontend certificate write.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"ssl_certificate": resourceschema.StringAttribute{
+			Required:    true,
+			Description: "Existing pfSense certificate reference to attach to the frontend. This must be a reference/name only, not PEM certificate or private key material. Terraform treats this as part of the natural key and requires replacement if it changes.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+	}
+}
+
+type haproxyFrontendCertificateKeys struct {
+	frontendName   string
+	sslCertificate string
+}
+
+func validateHaproxyFrontendCertificatePlan(model haproxyFrontendCertificateModel) (haproxyFrontendCertificateKeys, error) {
+	frontendName, err := haproxyFrontendCertificateFrontendName(model.FrontendName)
+	if err != nil {
+		return haproxyFrontendCertificateKeys{}, err
+	}
+	sslCertificate, err := haproxyFrontendCertificateSSLCertificate(model.SSLCertificate)
+	if err != nil {
+		return haproxyFrontendCertificateKeys{}, err
+	}
+
+	return haproxyFrontendCertificateKeys{frontendName: frontendName, sslCertificate: sslCertificate}, nil
+}
+
+func haproxyFrontendCertificateFrontendName(value types.String) (string, error) {
+	name, err := haproxyFrontendName(value)
+	if err != nil {
+		return "", fmt.Errorf("frontend_name %s", err.Error())
+	}
+
+	return name, nil
+}
+
+func haproxyFrontendCertificateSSLCertificate(value types.String) (string, error) {
+	if value.IsNull() || value.IsUnknown() {
+		return "", fmt.Errorf("ssl_certificate is required")
+	}
+
+	sslCertificate := value.ValueString()
+	if strings.TrimSpace(sslCertificate) == "" {
+		return "", fmt.Errorf("ssl_certificate must not be empty")
+	}
+	if strings.TrimSpace(sslCertificate) != sslCertificate {
+		return "", fmt.Errorf("ssl_certificate must not contain leading or trailing whitespace")
+	}
+	if strings.IndexFunc(sslCertificate, unicode.IsSpace) >= 0 {
+		return "", fmt.Errorf("ssl_certificate must not contain whitespace")
+	}
+	if strings.Contains(sslCertificate, "/") {
+		return "", fmt.Errorf("ssl_certificate must not contain /")
+	}
+
+	upper := strings.ToUpper(sslCertificate)
+	if strings.Contains(upper, "-----BEGIN") ||
+		strings.Contains(upper, "-----END") ||
+		strings.Contains(upper, "BEGIN CERTIFICATE") ||
+		strings.Contains(upper, "END CERTIFICATE") ||
+		strings.Contains(upper, "PRIVATE KEY") {
+		return "", fmt.Errorf("ssl_certificate must be an existing pfSense certificate reference, not certificate or private key material")
+	}
+
+	return sslCertificate, nil
+}
+
+func haproxyFrontendCertificateStateKeys(model haproxyFrontendCertificateModel) (haproxyFrontendCertificateKeys, error) {
+	if !model.FrontendName.IsNull() && !model.FrontendName.IsUnknown() &&
+		!model.SSLCertificate.IsNull() && !model.SSLCertificate.IsUnknown() {
+		return validateHaproxyFrontendCertificatePlan(model)
+	}
+	if !model.ID.IsNull() && !model.ID.IsUnknown() {
+		return parseHaproxyFrontendCertificateImportID(model.ID.ValueString())
+	}
+
+	return haproxyFrontendCertificateKeys{}, fmt.Errorf("state is missing frontend_name and ssl_certificate")
+}
+
+func parseHaproxyFrontendCertificateImportID(id string) (haproxyFrontendCertificateKeys, error) {
+	trimmed := strings.TrimSpace(id)
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 {
+		return haproxyFrontendCertificateKeys{}, fmt.Errorf("import pfsense_haproxy_frontend_certificate with ID frontend_name/ssl_certificate")
+	}
+	for _, part := range parts {
+		if part == "" {
+			return haproxyFrontendCertificateKeys{}, fmt.Errorf("import pfsense_haproxy_frontend_certificate with ID frontend_name/ssl_certificate")
+		}
+	}
+
+	frontendName, err := haproxyFrontendCertificateFrontendName(types.StringValue(parts[0]))
+	if err != nil {
+		return haproxyFrontendCertificateKeys{}, err
+	}
+	sslCertificate, err := haproxyFrontendCertificateSSLCertificate(types.StringValue(parts[1]))
+	if err != nil {
+		return haproxyFrontendCertificateKeys{}, err
+	}
+
+	return haproxyFrontendCertificateKeys{frontendName: frontendName, sslCertificate: sslCertificate}, nil
+}
+
+func buildHaproxyFrontendCertificateCreatePayload(parentID string, keys haproxyFrontendCertificateKeys) map[string]any {
+	return map[string]any{
+		"parent_id":       parentID,
+		"ssl_certificate": keys.sslCertificate,
+	}
+}
+
+func findHaproxyFrontendCertificate(ctx context.Context, client *pfsense.Client, parentID string, keys haproxyFrontendCertificateKeys) (haproxyFrontendCertificateModel, string, bool, error) {
+	var raw any
+	if err := client.Get(ctx, haproxyFrontendCertificatesQueryPath(parentID, keys), &raw); err != nil {
+		return haproxyFrontendCertificateModel{}, "", false, err
+	}
+
+	payloads, err := haproxyFrontendCertificatePayloadList(raw)
+	if err != nil {
+		return haproxyFrontendCertificateModel{}, "", false, err
+	}
+
+	var matched map[string]any
+	for _, payload := range payloads {
+		payloadMatches, err := haproxyFrontendCertificatePayloadMatches(payload, parentID, keys)
+		if err != nil {
+			return haproxyFrontendCertificateModel{}, "", false, err
+		}
+		if !payloadMatches {
+			continue
+		}
+		if matched != nil {
+			return haproxyFrontendCertificateModel{}, "", false, fmt.Errorf("multiple HAProxy frontend certificate attachments for %q were returned under frontend %q; certificate references must be unique within a frontend for Terraform management", keys.sslCertificate, keys.frontendName)
+		}
+		matched = payload
+	}
+
+	if matched == nil {
+		return haproxyFrontendCertificateModel{}, "", false, nil
+	}
+
+	apiID, err := apiRequiredScalarStringWithLabel(matched, "HAProxy frontend certificate", "id")
+	if err != nil {
+		return haproxyFrontendCertificateModel{}, "", false, fmt.Errorf("%w; confirm UAT returns child object IDs from GET %s before using delete", err, haproxyFrontendCertificatesPath)
+	}
+	model, err := haproxyFrontendCertificateModelFromAPI(matched, keys.frontendName)
+	if err != nil {
+		return haproxyFrontendCertificateModel{}, "", false, err
+	}
+
+	return model, apiID, true, nil
+}
+
+func haproxyFrontendCertificatePayloadMatches(payload map[string]any, parentID string, keys haproxyFrontendCertificateKeys) (bool, error) {
+	if value, name, ok := apiValue(payload, "parent_id"); ok && value != nil {
+		payloadParentID, err := scalarStringValue("HAProxy frontend certificate", name, value)
+		if err != nil {
+			return false, err
+		}
+		if payloadParentID != parentID {
+			return false, nil
+		}
+	}
+
+	sslCertificateValue, err := apiRequiredStringWithLabel(payload, "HAProxy frontend certificate", "ssl_certificate")
+	if err != nil {
+		return false, err
+	}
+	sslCertificate, err := haproxyFrontendCertificateSSLCertificate(types.StringValue(sslCertificateValue))
+	if err != nil {
+		return false, fmt.Errorf("HAProxy frontend certificate ssl_certificate %s", err.Error())
+	}
+
+	return sslCertificate == keys.sslCertificate, nil
+}
+
+func haproxyFrontendCertificatePayloadList(raw any) ([]map[string]any, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	switch typed := raw.(type) {
+	case []any:
+		payloads := make([]map[string]any, 0, len(typed))
+		for index, item := range typed {
+			payload, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("HAProxy frontend certificates response item %d has unsupported type %T", index, item)
+			}
+			payloads = append(payloads, payload)
+		}
+		return payloads, nil
+	case []map[string]any:
+		return typed, nil
+	case map[string]any:
+		return []map[string]any{typed}, nil
+	default:
+		return nil, fmt.Errorf("HAProxy frontend certificates response has unsupported type %T; confirm the live UAT /services/haproxy/frontend/certificates schema", raw)
+	}
+}
+
+func haproxyFrontendCertificateModelFromAPI(payload map[string]any, frontendName string) (haproxyFrontendCertificateModel, error) {
+	certificate := nullHaproxyFrontendCertificateModel()
+
+	sslCertificateValue, err := apiRequiredStringWithLabel(payload, "HAProxy frontend certificate", "ssl_certificate")
+	if err != nil {
+		return certificate, err
+	}
+	sslCertificate, err := haproxyFrontendCertificateSSLCertificate(types.StringValue(sslCertificateValue))
+	if err != nil {
+		return certificate, fmt.Errorf("HAProxy frontend certificate ssl_certificate %s", err.Error())
+	}
+
+	keys := haproxyFrontendCertificateKeys{frontendName: frontendName, sslCertificate: sslCertificate}
+	certificate.ID = types.StringValue(haproxyFrontendCertificateTerraformID(keys))
+	certificate.FrontendName = types.StringValue(frontendName)
+	certificate.SSLCertificate = types.StringValue(sslCertificate)
+
+	return certificate, nil
+}
+
+func nullHaproxyFrontendCertificateModel() haproxyFrontendCertificateModel {
+	return haproxyFrontendCertificateModel{
+		ID:             types.StringNull(),
+		FrontendName:   types.StringNull(),
+		SSLCertificate: types.StringNull(),
+	}
+}
+
+func haproxyFrontendCertificatesQueryPath(parentID string, keys haproxyFrontendCertificateKeys) string {
+	values := url.Values{}
+	values.Set("parent_id", parentID)
+	values.Set("ssl_certificate", keys.sslCertificate)
+	return haproxyFrontendCertificatesPath + "?" + values.Encode()
+}
+
+func haproxyFrontendCertificateDeletePath(parentID string, certificateID string) string {
+	values := url.Values{}
+	values.Set("parent_id", parentID)
+	values.Set("id", certificateID)
+	return haproxyFrontendCertificatePath + "?" + values.Encode()
+}
+
+func haproxyFrontendCertificateTerraformID(keys haproxyFrontendCertificateKeys) string {
+	return keys.frontendName + "/" + keys.sslCertificate
+}
+
+func frontendCertificateLookupErrorDetail(keys haproxyFrontendCertificateKeys, err error) string {
+	return fmt.Sprintf("%s. Confirm GET %s is available on UAT, accepts parent_id and ssl_certificate query filters, returns frontend certificate attachment objects with stable ssl_certificate fields, and includes the transient pfSense child object id required for delete. Frontend name: %q. Certificate reference: %q.", err.Error(), haproxyFrontendCertificatesPath, keys.frontendName, keys.sslCertificate)
+}
+
+func frontendCertificateParentLookupErrorDetail(frontendName string, err error) string {
+	return fmt.Sprintf("%s. Confirm GET %s is available on UAT, returns one frontend object with a stable name field, and includes the transient pfSense frontend object id required to query child certificate attachments. Frontend name: %q.", err.Error(), haproxyFrontendsPath, frontendName)
+}

--- a/internal/provider/haproxy_frontend_certificate_test.go
+++ b/internal/provider/haproxy_frontend_certificate_test.go
@@ -1,0 +1,492 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestHaproxyFrontendCertificateResourceCreateUsesParentLookupAndDoesNotApply(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	var postPayload map[string]any
+	certificateLookupCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v2/services/haproxy/frontends":
+			if got := r.URL.Query().Get("name"); got != "app_frontend" {
+				t.Fatalf("frontend lookup name = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":42,"name":"app_frontend","type":"http"}]}`))
+		case http.MethodGet + " /api/v2/services/haproxy/frontend/certificates":
+			assertFrontendCertificateLookupQuery(t, r, "42", "existing_cert_ref")
+			certificateLookupCount++
+			if certificateLookupCount == 1 {
+				_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":6,"parent_id":42,"ssl_certificate":"other_cert_ref"}]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{
+				"code": 200,
+				"status": "ok",
+				"data": [
+					{"id": 6, "parent_id": 42, "ssl_certificate": "other_cert_ref"},
+					{"id": 7, "parent_id": 42, "ssl_certificate": "existing_cert_ref"}
+				]
+			}`))
+		case http.MethodPost + " /api/v2/services/haproxy/frontend/certificate":
+			if err := json.NewDecoder(r.Body).Decode(&postPayload); err != nil {
+				t.Fatalf("decode POST payload: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":{"id":7}}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	certificateResource := &haproxyFrontendCertificateResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyFrontendCertificateResourceSchema(t)
+	plan := nullHaproxyFrontendCertificateModel()
+	plan.FrontendName = types.StringValue("app_frontend")
+	plan.SSLCertificate = types.StringValue("existing_cert_ref")
+
+	resp := resource.CreateResponse{
+		State: testResourceState(t, schema, plan),
+	}
+	certificateResource.Create(context.Background(), resource.CreateRequest{
+		Plan: testResourcePlan(t, schema, plan),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/frontends?name=app_frontend",
+		"GET /api/v2/services/haproxy/frontend/certificates?parent_id=42&ssl_certificate=existing_cert_ref",
+		"POST /api/v2/services/haproxy/frontend/certificate",
+		"GET /api/v2/services/haproxy/frontend/certificates?parent_id=42&ssl_certificate=existing_cert_ref",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+
+	if postPayload["parent_id"] != "42" || postPayload["ssl_certificate"] != "existing_cert_ref" {
+		t.Fatalf("POST payload = %#v", postPayload)
+	}
+	for _, forbidden := range []string{"id", "apply", "async", "certificate", "cert", "crt", "pem", "private_key", "key", "content"} {
+		if _, ok := postPayload[forbidden]; ok {
+			t.Fatalf("POST unexpectedly included %q: %#v", forbidden, postPayload)
+		}
+	}
+
+	var state haproxyFrontendCertificateModel
+	diags := resp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.ID.ValueString() != "app_frontend/existing_cert_ref" || state.FrontendName.ValueString() != "app_frontend" || state.SSLCertificate.ValueString() != "existing_cert_ref" {
+		t.Fatalf("natural key not preserved in state: %#v", state)
+	}
+}
+
+func TestHaproxyFrontendCertificateResourceCreateRejectsDuplicate(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v2/services/haproxy/frontends":
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":42,"name":"app_frontend","type":"http"}]}`))
+		case http.MethodGet + " /api/v2/services/haproxy/frontend/certificates":
+			assertFrontendCertificateLookupQuery(t, r, "42", "existing_cert_ref")
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":7,"ssl_certificate":"existing_cert_ref"}]}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	certificateResource := &haproxyFrontendCertificateResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyFrontendCertificateResourceSchema(t)
+	plan := nullHaproxyFrontendCertificateModel()
+	plan.FrontendName = types.StringValue("app_frontend")
+	plan.SSLCertificate = types.StringValue("existing_cert_ref")
+
+	var resp resource.CreateResponse
+	resp.State = testResourceState(t, schema, plan)
+	certificateResource.Create(context.Background(), resource.CreateRequest{
+		Plan: testResourcePlan(t, schema, plan),
+	}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected duplicate certificate diagnostic")
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d", requests.Load())
+	}
+	if !strings.Contains(diagnosticsText(resp.Diagnostics), "terraform import") {
+		t.Fatalf("diagnostics did not include import guidance: %s", diagnosticsText(resp.Diagnostics))
+	}
+}
+
+func TestHaproxyFrontendCertificateResourceCreateErrorsWhenParentMissing(t *testing.T) {
+	t.Parallel()
+
+	var requests []string
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		if r.Method != http.MethodGet || r.URL.RequestURI() != "/api/v2/services/haproxy/frontends?name=missing_frontend" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	certificateResource := &haproxyFrontendCertificateResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyFrontendCertificateResourceSchema(t)
+	plan := nullHaproxyFrontendCertificateModel()
+	plan.FrontendName = types.StringValue("missing_frontend")
+	plan.SSLCertificate = types.StringValue("existing_cert_ref")
+
+	var resp resource.CreateResponse
+	resp.State = testResourceState(t, schema, plan)
+	certificateResource.Create(context.Background(), resource.CreateRequest{
+		Plan: testResourcePlan(t, schema, plan),
+	}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected missing parent diagnostic")
+	}
+	if !strings.Contains(diagnosticsText(resp.Diagnostics), "Parent frontend") {
+		t.Fatalf("diagnostics did not describe missing parent: %s", diagnosticsText(resp.Diagnostics))
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{"GET /api/v2/services/haproxy/frontends?name=missing_frontend"}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+}
+
+func TestHaproxyFrontendCertificateResourceReadRemovesWhenChildMissing(t *testing.T) {
+	t.Parallel()
+
+	var requests []string
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v2/services/haproxy/frontends":
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":42,"name":"app_frontend","type":"http"}]}`))
+		case http.MethodGet + " /api/v2/services/haproxy/frontend/certificates":
+			assertFrontendCertificateLookupQuery(t, r, "42", "existing_cert_ref")
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[]}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	certificateResource := &haproxyFrontendCertificateResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyFrontendCertificateResourceSchema(t)
+	stateModel := nullHaproxyFrontendCertificateModel()
+	stateModel.ID = types.StringValue("app_frontend/existing_cert_ref")
+	stateModel.FrontendName = types.StringValue("app_frontend")
+	stateModel.SSLCertificate = types.StringValue("existing_cert_ref")
+
+	resp := resource.ReadResponse{
+		State: testResourceState(t, schema, stateModel),
+	}
+	certificateResource.Read(context.Background(), resource.ReadRequest{
+		State: testResourceState(t, schema, stateModel),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatalf("missing certificate did not remove child state")
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/frontends?name=app_frontend",
+		"GET /api/v2/services/haproxy/frontend/certificates?parent_id=42&ssl_certificate=existing_cert_ref",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+}
+
+func TestHaproxyFrontendCertificateResourceUpdateDoesNotPatch(t *testing.T) {
+	t.Parallel()
+
+	certificateResource := &haproxyFrontendCertificateResource{}
+	var resp resource.UpdateResponse
+	certificateResource.Update(context.Background(), resource.UpdateRequest{}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected update diagnostic")
+	}
+	if !strings.Contains(diagnosticsText(resp.Diagnostics), "require replacement") {
+		t.Fatalf("diagnostics did not describe replacement-only behavior: %s", diagnosticsText(resp.Diagnostics))
+	}
+}
+
+func TestHaproxyFrontendCertificateResourceDeleteResolvesCurrentParentAndCertificateIDs(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case http.MethodGet + " /api/v2/services/haproxy/frontends":
+			if got := r.URL.Query().Get("name"); got != "app_frontend" {
+				t.Fatalf("frontend lookup name = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":99,"name":"app_frontend","type":"http"}]}`))
+		case http.MethodGet + " /api/v2/services/haproxy/frontend/certificates":
+			assertFrontendCertificateLookupQuery(t, r, "99", "existing_cert_ref")
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":[{"id":7,"ssl_certificate":"existing_cert_ref"}]}`))
+		case http.MethodDelete + " /api/v2/services/haproxy/frontend/certificate":
+			if got := r.URL.Query().Get("parent_id"); got != "99" {
+				t.Fatalf("delete parent_id = %q", got)
+			}
+			if got := r.URL.Query().Get("id"); got != "7" {
+				t.Fatalf("delete id = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"code":200,"status":"ok","data":null}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	certificateResource := &haproxyFrontendCertificateResource{
+		client: pfsense.NewClient(pfsense.Config{Endpoint: server.URL, APIKey: "test-key"}),
+	}
+	schema := haproxyFrontendCertificateResourceSchema(t)
+	stateModel := nullHaproxyFrontendCertificateModel()
+	stateModel.ID = types.StringValue("app_frontend/existing_cert_ref")
+	stateModel.FrontendName = types.StringValue("app_frontend")
+	stateModel.SSLCertificate = types.StringValue("existing_cert_ref")
+
+	resp := resource.DeleteResponse{
+		State: testResourceState(t, schema, stateModel),
+	}
+	certificateResource.Delete(context.Background(), resource.DeleteRequest{
+		State: testResourceState(t, schema, stateModel),
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", resp.Diagnostics)
+	}
+
+	mu.Lock()
+	gotRequests := append([]string(nil), requests...)
+	mu.Unlock()
+	wantRequests := []string{
+		"GET /api/v2/services/haproxy/frontends?name=app_frontend",
+		"GET /api/v2/services/haproxy/frontend/certificates?parent_id=99&ssl_certificate=existing_cert_ref",
+		"DELETE /api/v2/services/haproxy/frontend/certificate?id=7&parent_id=99",
+	}
+	if !reflect.DeepEqual(gotRequests, wantRequests) {
+		t.Fatalf("requests = %#v, want %#v", gotRequests, wantRequests)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatalf("state was not removed")
+	}
+}
+
+func TestHaproxyFrontendCertificateResourceImportUsesNaturalKey(t *testing.T) {
+	t.Parallel()
+
+	certificateResource := &haproxyFrontendCertificateResource{}
+	schema := haproxyFrontendCertificateResourceSchema(t)
+
+	validResp := resource.ImportStateResponse{
+		State: tfsdk.State{Schema: schema},
+	}
+	certificateResource.ImportState(context.Background(), resource.ImportStateRequest{ID: "app_frontend/existing_cert_ref"}, &validResp)
+	if validResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", validResp.Diagnostics)
+	}
+	var state haproxyFrontendCertificateModel
+	diags := validResp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("state get diagnostics: %#v", diags)
+	}
+	if state.ID.ValueString() != "app_frontend/existing_cert_ref" || state.FrontendName.ValueString() != "app_frontend" || state.SSLCertificate.ValueString() != "existing_cert_ref" {
+		t.Fatalf("imported state = %#v", state)
+	}
+
+	for _, id := range []string{
+		"",
+		"app_frontend",
+		"app_frontend/",
+		"/existing_cert_ref",
+		"app/frontend/existing_cert_ref",
+		"app_frontend/existing cert ref",
+		"app_frontend/existing\ncert",
+		"app_frontend/-----BEGINCERTIFICATE-----",
+	} {
+		invalidResp := resource.ImportStateResponse{
+			State: tfsdk.State{Schema: schema},
+		}
+		certificateResource.ImportState(context.Background(), resource.ImportStateRequest{ID: id}, &invalidResp)
+		if !invalidResp.Diagnostics.HasError() {
+			t.Fatalf("expected diagnostic for import id %q", id)
+		}
+	}
+}
+
+func TestHaproxyFrontendCertificateValidation(t *testing.T) {
+	t.Parallel()
+
+	valid := nullHaproxyFrontendCertificateModel()
+	valid.FrontendName = types.StringValue("app_frontend")
+	valid.SSLCertificate = types.StringValue("existing_cert_ref")
+
+	if _, err := validateHaproxyFrontendCertificatePlan(valid); err != nil {
+		t.Fatalf("valid certificate attachment rejected: %v", err)
+	}
+
+	tests := map[string]haproxyFrontendCertificateModel{
+		"frontend slash": func() haproxyFrontendCertificateModel {
+			model := valid
+			model.FrontendName = types.StringValue("app/frontend")
+			return model
+		}(),
+		"empty certificate": func() haproxyFrontendCertificateModel {
+			model := valid
+			model.SSLCertificate = types.StringValue("")
+			return model
+		}(),
+		"whitespace certificate": func() haproxyFrontendCertificateModel {
+			model := valid
+			model.SSLCertificate = types.StringValue("existing cert ref")
+			return model
+		}(),
+		"leading whitespace": func() haproxyFrontendCertificateModel {
+			model := valid
+			model.SSLCertificate = types.StringValue(" existing_cert_ref")
+			return model
+		}(),
+		"newline certificate": func() haproxyFrontendCertificateModel {
+			model := valid
+			model.SSLCertificate = types.StringValue("existing\ncert")
+			return model
+		}(),
+		"certificate slash": func() haproxyFrontendCertificateModel {
+			model := valid
+			model.SSLCertificate = types.StringValue("existing/cert")
+			return model
+		}(),
+		"pem certificate": func() haproxyFrontendCertificateModel {
+			model := valid
+			model.SSLCertificate = types.StringValue("-----BEGINCERTIFICATE-----")
+			return model
+		}(),
+		"pem trailer": func() haproxyFrontendCertificateModel {
+			model := valid
+			model.SSLCertificate = types.StringValue("-----ENDCERTIFICATE-----")
+			return model
+		}(),
+		"private key material": func() haproxyFrontendCertificateModel {
+			model := valid
+			model.SSLCertificate = types.StringValue("-----BEGINPRIVATEKEY-----")
+			return model
+		}(),
+	}
+
+	for name, model := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := validateHaproxyFrontendCertificatePlan(model); err == nil {
+				t.Fatalf("expected validation error")
+			}
+		})
+	}
+}
+
+func TestHaproxyFrontendCertificateSchemaIsConservative(t *testing.T) {
+	schema := haproxyFrontendCertificateResourceSchema(t)
+	for _, required := range []string{"frontend_name", "ssl_certificate"} {
+		if _, ok := schema.Attributes[required]; !ok {
+			t.Fatalf("resource schema missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{"parent_id", "rest_id", "api_id", "id_api", "apply", "async", "certificate", "cert", "crt", "pem", "private_key", "key", "content"} {
+		if _, ok := schema.Attributes[forbidden]; ok {
+			t.Fatalf("resource schema should not expose %q", forbidden)
+		}
+	}
+}
+
+func assertFrontendCertificateLookupQuery(t *testing.T, r *http.Request, parentID string, sslCertificate string) {
+	t.Helper()
+
+	if got := r.URL.Query().Get("parent_id"); got != parentID {
+		t.Fatalf("certificate lookup parent_id = %q", got)
+	}
+	if got := r.URL.Query().Get("ssl_certificate"); got != sslCertificate {
+		t.Fatalf("certificate lookup ssl_certificate = %q", got)
+	}
+}
+
+func haproxyFrontendCertificateResourceSchema(t *testing.T) resourceschema.Schema {
+	t.Helper()
+
+	var resp resource.SchemaResponse
+	(&haproxyFrontendCertificateResource{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected resource schema diagnostics: %#v", resp.Diagnostics)
+	}
+
+	return resp.Schema
+}

--- a/internal/provider/haproxy_frontend_certificate_test.go
+++ b/internal/provider/haproxy_frontend_certificate_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 
 	"github.com/d3vi1/terraform-provider-pfsense-restapi-haproxy/internal/pfsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -451,6 +453,40 @@ func TestHaproxyFrontendCertificateValidation(t *testing.T) {
 				t.Fatalf("expected validation error")
 			}
 		})
+	}
+}
+
+func TestHaproxyFrontendCertificateReferenceValidatorRejectsSecretMaterialAtConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []types.String{
+		types.StringValue(" existing_cert_ref"),
+		types.StringValue("existing/cert"),
+		types.StringValue("existing\ncert"),
+		types.StringValue("-----BEGIN CERTIFICATE-----"),
+		types.StringValue("-----BEGIN PRIVATE KEY-----"),
+	}
+
+	for _, value := range tests {
+		t.Run(value.ValueString(), func(t *testing.T) {
+			var resp validator.StringResponse
+			haproxyFrontendCertificateReferenceValidator{}.ValidateString(context.Background(), validator.StringRequest{
+				Path:        path.Root("ssl_certificate"),
+				ConfigValue: value,
+			}, &resp)
+			if !resp.Diagnostics.HasError() {
+				t.Fatalf("expected validator diagnostic for %q", value.ValueString())
+			}
+		})
+	}
+
+	var validResp validator.StringResponse
+	haproxyFrontendCertificateReferenceValidator{}.ValidateString(context.Background(), validator.StringRequest{
+		Path:        path.Root("ssl_certificate"),
+		ConfigValue: types.StringValue("existing_cert_ref"),
+	}, &validResp)
+	if validResp.Diagnostics.HasError() {
+		t.Fatalf("valid certificate reference rejected: %#v", validResp.Diagnostics)
 	}
 }
 

--- a/internal/provider/haproxy_settings_test.go
+++ b/internal/provider/haproxy_settings_test.go
@@ -40,6 +40,9 @@ func TestProviderRegistersHaproxySettings(t *testing.T) {
 	if !resourceTypeRegistered(resources, "pfsense_haproxy_frontend_address") {
 		t.Fatalf("pfsense_haproxy_frontend_address resource was not registered")
 	}
+	if !resourceTypeRegistered(resources, "pfsense_haproxy_frontend_certificate") {
+		t.Fatalf("pfsense_haproxy_frontend_certificate resource was not registered")
+	}
 	if !resourceTypeRegistered(resources, "pfsense_haproxy_settings") {
 		t.Fatalf("pfsense_haproxy_settings resource was not registered")
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -123,6 +123,7 @@ func (p *haproxyProvider) Resources(_ context.Context) []func() resource.Resourc
 		newHaproxyBackendServerResource,
 		newHaproxyFrontendResource,
 		newHaproxyFrontendAddressResource,
+		newHaproxyFrontendCertificateResource,
 		newHaproxySettingsResource,
 	}
 }


### PR DESCRIPTION
Closes #13.

## Summary
- Add `pfsense_haproxy_frontend_certificate` as a replacement-only child resource for attaching existing pfSense certificate references to HAProxy frontends.
- Resolve the parent frontend by natural name, look up child certificate attachments by `parent_id` and `ssl_certificate`, create via the singular certificate endpoint, and delete via `parent_id` plus child `id`.
- Reject empty, slash-containing, whitespace/newline-containing, PEM-looking, and private-key-looking `ssl_certificate` values; no certificate/private key material fields are exposed.
- Register the resource and document examples, schema decisions, endpoint inventory, and explicit apply triggers.

## Validation
- `gofmt` on changed Go files
- `go test ./...`
- `make test`
- `make lint`
- `git diff --check`
- `terraform fmt -check -recursive .`
- `python3 -m unittest scripts/capture_haproxy_schema_test.py`

## Notes
- UAT validation remains pending for the live pfSense response shape of `/services/haproxy/frontend/certificates`. The implementation requires returned child objects to include `id` and `ssl_certificate`.