### PR TITLE
Document HAProxy file resource deferral

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ children by parent/frontend name, listen address, custom address, and port.
 references to frontends without managing certificate or private key material.
 Backend and backend server lookup data sources are available for read-only
 references to existing HAProxy objects. Additional HAProxy resources are tracked
-through GitHub issues and milestones.
+through GitHub issues and milestones. `pfsense_haproxy_file` is intentionally
+deferred until UAT confirms the HAProxy file endpoint semantics and a security
+model is selected for secret-bearing file content.
 
 ## Requirements
 
@@ -306,6 +308,24 @@ create/delete use the documented child `parent_id` contract; and certificate
 attachment writes only mark HAProxy configuration pending until a separate
 `pfsense_haproxy_apply` resource is used.
 
+## Deferred HAProxy files
+
+`pfsense_haproxy_file` is intentionally deferred out of M4. The current M4
+resources for frontends, frontend addresses, and frontend certificate
+attachments do not require `HAProxyFile.content` for their lifecycle.
+
+The REST API's `HAProxyFile.content` field can carry custom error pages,
+snippets, or other HAProxy text that may contain private material. Before this
+provider manages it, a later issue must pass these gates:
+
+- A managed error-file or snippet use case requires first-class HAProxy file
+  ownership.
+- UAT confirms `/services/haproxy/file` and `/services/haproxy/files` response
+  shape, import identity, read-after-write behavior, and whether reads return
+  file content.
+- A security model is selected for either sensitive Terraform state content or
+  write-only content with a caller-supplied content hash for drift detection.
+
 ## Development
 
 ```bash
@@ -333,10 +353,13 @@ make testacc
 - `pfsense_haproxy_backend_server`
 - `pfsense_haproxy_settings`
 
-## Planned resources
+## Planned and deferred resources
 
 - `pfsense_haproxy_frontend_acl`
 - `pfsense_haproxy_frontend_action`
+
+Deferred pending UAT and security-model gates:
+
 - `pfsense_haproxy_file`
 
 ## Example ingress contract

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -135,3 +135,13 @@ the current child ID before delete, and manages only the existing
 `ssl_certificate` reference. The resource intentionally does not expose
 certificate bodies, private key material, PEM content, placement controls,
 advanced fields, or a PATCH update path.
+
+For M4-04, `pfsense_haproxy_file` is deferred out of M4. The implemented M4
+frontend, frontend address, and frontend certificate resources do not require
+`HAProxyFile.content`. That field is secret-bearing because HAProxy file
+payloads can contain custom error pages, snippets, or other text with private
+material. A future implementation must first prove a managed error-file or
+snippet dependency, confirm `/services/haproxy/file` and
+`/services/haproxy/files` response and import semantics on UAT, and select a
+security model between sensitive Terraform state content and write-only content
+plus a caller-supplied content hash for drift detection.

--- a/docs/schema/haproxy-endpoint-inventory.md
+++ b/docs/schema/haproxy-endpoint-inventory.md
@@ -30,8 +30,8 @@ published documentation.
 | `/api/v2/services/haproxy/backend/server` | GET, POST, PATCH, DELETE | Singular | HAProxyBackendServer | pfSense-pkg-haproxy | Implemented in M3-02; UAT pending |
 | `/api/v2/services/haproxy/backend/servers` | GET, DELETE | Plural | HAProxyBackendServer | pfSense-pkg-haproxy | Implemented in M3-02; UAT pending |
 | `/api/v2/services/haproxy/backends` | GET, PUT, DELETE | Plural | HAProxyBackend | pfSense-pkg-haproxy | Pending |
-| `/api/v2/services/haproxy/file` | GET, POST, PATCH, DELETE | Singular | HAProxyFile | pfSense-pkg-haproxy | Pending |
-| `/api/v2/services/haproxy/files` | GET, PUT, DELETE | Plural | HAProxyFile | pfSense-pkg-haproxy | Pending |
+| `/api/v2/services/haproxy/file` | GET, POST, PATCH, DELETE | Singular | HAProxyFile | pfSense-pkg-haproxy | Deferred pending UAT; not implemented |
+| `/api/v2/services/haproxy/files` | GET, PUT, DELETE | Plural | HAProxyFile | pfSense-pkg-haproxy | Deferred pending UAT; not implemented |
 | `/api/v2/services/haproxy/frontend/acl` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendACL | pfSense-pkg-haproxy | Pending |
 | `/api/v2/services/haproxy/frontend/acls` | GET, DELETE | Plural | HAProxyFrontendACL | pfSense-pkg-haproxy | Pending |
 | `/api/v2/services/haproxy/frontend/action` | GET, POST, PATCH, DELETE | Singular | HAProxyFrontendAction | pfSense-pkg-haproxy | Pending |
@@ -56,5 +56,9 @@ published documentation.
 - Confirm package name and version metadata from `/api/v2/schema/native`.
 - Confirm singular object ID behavior and child `parent_id` behavior from live
   schema metadata before implementing import or drift detection.
+- HAProxy file endpoints are deferred until UAT confirms
+  `/api/v2/services/haproxy/file` and `/api/v2/services/haproxy/files`
+  response/import semantics and a security model is selected for
+  `HAProxyFile.content`.
 - Do not use plural `PUT` replacement or plural `DELETE` endpoints from
   Terraform resources until an import/migration plan exists.

--- a/docs/schema/resource-schema-decisions.md
+++ b/docs/schema/resource-schema-decisions.md
@@ -50,7 +50,7 @@ Primary references:
 | `pfsense_haproxy_frontend_action` | HAProxyFrontendAction | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/action` | Create requires `parent_id` plus action-specific fields in the public schema. | Child resource under frontend. Conditional fields need UAT examples before strict Terraform validation. |
 | `pfsense_haproxy_frontend_certificate` | HAProxyFrontendCertificate | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/certificate`; `GET /frontend/certificates` | Create requires `parent_id`; schema exposes `ssl_certificate`. | Implemented in M4-03 as a frontend child resource using `frontend_name/ssl_certificate` as Terraform's stable natural key. Before create/delete, resolve the current parent frontend ID by frontend name; before delete, resolve the current child ID by exact certificate reference under that parent. Manage only existing `ssl_certificate` references; reject PEM/private-key-looking values; do not expose certificate bodies, private keys, placement, advanced fields, or a PATCH update path. |
 | `pfsense_haproxy_frontend_error_file` | HAProxyFrontendErrorFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/frontend/error_file` | Create requires `parent_id`, `errorcode`, `errorfile`. | Child resource under frontend. Consider later if required for managed routes. |
-| `pfsense_haproxy_file` | HAProxyFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/file`; `GET /files` | Create requires `name`, `content`. Patch requires `id`. | Defer until routes require managed HAProxy files. `content` must be sensitive in Terraform state and excluded from schema fixtures. |
+| `pfsense_haproxy_file` | HAProxyFile | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/file`; `GET /files` | Create requires `name`, `content`. Patch requires `id`. | Deferred out of M4. Current M4 frontend, frontend address, and frontend certificate resources do not require `HAProxyFile.content`; the field can carry secret-bearing error pages, snippets, or HAProxy text. Future implementation is gated on a managed error-file/snippet dependency, UAT confirmation of `/services/haproxy/file` and `/services/haproxy/files` response/import semantics, and an explicit security model: either sensitive Terraform state content or write-only content with a caller-supplied content hash for drift detection. |
 | `pfsense_haproxy_settings_dns_resolver` | HAProxyDNSResolver | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/settings/dns_resolver` | Create requires `name`, `server`. Patch requires `id`. | Model as settings child only if needed. Pending UAT confirmation of nesting and IDs. |
 | `pfsense_haproxy_settings_email_mailer` | HAProxyEmailMailer | `GET/POST/PATCH/DELETE /api/v2/services/haproxy/settings/email_mailer` | Create requires `name`, `mailserver`. Patch requires `id`. | Model as settings child only if needed. Pending UAT confirmation of nesting and IDs. |
 | `pfsense_haproxy_apply` | HAProxyApply | `GET/POST /api/v2/services/haproxy/apply` | `GET` reports `applied`; `POST` applies pending changes. | Implemented in M2-02 as a status data source and singleton action resource with fixed ID `apply`, user-controlled `triggers`, POST guarded by the shared client write guard, bounded polling, state-only delete, and no hidden apply behavior in other resources. |
@@ -97,6 +97,16 @@ Primary references:
 - Confirm whether frontend certificate attachments support ordering/placement
   semantics on UAT. The first implementation intentionally does not set
   placement and treats changes as replacement-only.
+- Confirm `/api/v2/services/haproxy/file` and
+  `/api/v2/services/haproxy/files` behavior before implementing
+  `pfsense_haproxy_file`, including object identity, whether reads return
+  `content`, whether imports can reconstruct state without storing raw content,
+  and create/update response envelopes.
+- Confirm whether managed frontend or backend error-file/snippet resources need
+  first-class HAProxy file ownership before implementing `pfsense_haproxy_file`.
+- Select the HAProxy file security model before implementation: sensitive
+  Terraform state content or write-only content plus caller-supplied content
+  hash for drift detection.
 - Whether published conditional fields such as `agent_port` and
   `persist_cookie_name` are required only when their enabling booleans are true
   on UAT.


### PR DESCRIPTION
## Summary

- Documents the decision to defer `pfsense_haproxy_file` out of M4.
- Records the deferral rationale: current M4 frontend/address/certificate resources do not need `HAProxyFile.content`, file content can be secret-bearing, and UAT response/import semantics remain unconfirmed.
- Adds future implementation gates for managed error-file/snippet dependency, `/services/haproxy/file(s)` UAT confirmation, and selecting sensitive-state vs write-only content/hash security handling.

## Validation

- `git diff --check`
- `make test`

Closes #14