### PR TITLE
Clear frontend HTTP-only fields on TCP transition

### DIFF
--- a/internal/provider/haproxy_frontend.go
+++ b/internal/provider/haproxy_frontend.go
@@ -306,7 +306,7 @@ func haproxyFrontendResourceSchemaAttributes() map[string]resourceschema.Attribu
 		},
 		"name": resourceschema.StringAttribute{
 			Required:    true,
-			Description: "Unique HAProxy frontend name. Names must contain at least two letters, numbers, dots, hyphens, or underscores. Terraform treats this as the natural key and requires replacement if it changes.",
+			Description: "Unique HAProxy frontend name. Names may contain letters, numbers, dots, hyphens, or underscores. Terraform treats this as the natural key and requires replacement if it changes.",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},
@@ -388,7 +388,7 @@ func validateHaproxyFrontendOptionalFields(model haproxyFrontendModel, frontendT
 	if !model.ClientTimeout.IsNull() && !model.ClientTimeout.IsUnknown() && model.ClientTimeout.ValueInt64() < 0 {
 		return fmt.Errorf("client_timeout must be non-negative")
 	}
-	if !model.ForwardFor.IsNull() && !model.ForwardFor.IsUnknown() && model.ForwardFor.ValueBool() && frontendType != "http" {
+	if !model.ForwardFor.IsNull() && !model.ForwardFor.IsUnknown() && frontendType != "http" {
 		return fmt.Errorf("forwardfor is only valid when type is http")
 	}
 
@@ -469,12 +469,19 @@ func buildHaproxyFrontendPatch(plan haproxyFrontendModel, prior haproxyFrontendM
 	if !plan.Type.IsUnknown() && !plan.Type.Equal(prior.Type) {
 		patch["type"] = plan.Type.ValueString()
 	}
+	clearHTTPOnlyFields := !plan.Type.IsNull() && !plan.Type.IsUnknown() &&
+		plan.Type.ValueString() == "tcp" &&
+		!prior.Type.IsNull() && !prior.Type.IsUnknown() &&
+		prior.Type.ValueString() == "http"
 
 	planValues := plan.attrValues()
 	priorValues := prior.attrValues()
 	for _, attribute := range haproxyFrontendAttributes {
 		planned := planValues[attribute.Name]
 		if planned.IsUnknown() {
+			if clearHTTPOnlyFields && haproxyFrontendAttributeHTTPOnly(attribute.Name) && !priorValues[attribute.Name].IsNull() && !priorValues[attribute.Name].IsUnknown() {
+				patch[attribute.JSONName] = nil
+			}
 			continue
 		}
 		if planned.Equal(priorValues[attribute.Name]) {
@@ -485,6 +492,15 @@ func buildHaproxyFrontendPatch(plan haproxyFrontendModel, prior haproxyFrontendM
 	}
 
 	return patch
+}
+
+func haproxyFrontendAttributeHTTPOnly(name string) bool {
+	switch name {
+	case "forwardfor", "httpclose":
+		return true
+	default:
+		return false
+	}
 }
 
 func findHaproxyFrontendByName(ctx context.Context, client *pfsense.Client, name string) (haproxyFrontendModel, string, bool, error) {

--- a/internal/provider/haproxy_frontend_test.go
+++ b/internal/provider/haproxy_frontend_test.go
@@ -357,6 +357,33 @@ func TestHaproxyFrontendResourceUpdateResolvesAPIIDAndPatchesChangedFieldsOnly(t
 	}
 }
 
+func TestHaproxyFrontendResourceUpdateClearsHTTPOnlyFieldsWhenTypeSwitchesToTCP(t *testing.T) {
+	t.Parallel()
+
+	prior := nullHaproxyFrontendModel()
+	prior.ID = types.StringValue("app_frontend")
+	prior.Name = types.StringValue("app_frontend")
+	prior.Type = types.StringValue("http")
+	prior.ForwardFor = types.BoolValue(true)
+	prior.HTTPClose = types.StringValue("http-server-close")
+
+	plan := prior
+	plan.Type = types.StringValue("tcp")
+	plan.ForwardFor = types.BoolUnknown()
+	plan.HTTPClose = types.StringUnknown()
+
+	patch := buildHaproxyFrontendPatch(plan, prior, "42")
+	if patch["type"] != "tcp" {
+		t.Fatalf("patch type = %#v, want tcp", patch["type"])
+	}
+	if value, ok := patch["forwardfor"]; !ok || value != nil {
+		t.Fatalf("patch forwardfor = %#v, want explicit null", patch)
+	}
+	if value, ok := patch["httpclose"]; !ok || value != nil {
+		t.Fatalf("patch httpclose = %#v, want explicit null", patch)
+	}
+}
+
 func TestHaproxyFrontendResourceUpdateSkipsPatchWithoutChanges(t *testing.T) {
 	t.Parallel()
 
@@ -561,6 +588,12 @@ func TestHaproxyFrontendValidation(t *testing.T) {
 			model := valid
 			model.Type = types.StringValue("tcp")
 			model.ForwardFor = types.BoolValue(true)
+			return model
+		}(),
+		"forwardfor false tcp": func() haproxyFrontendModel {
+			model := valid
+			model.Type = types.StringValue("tcp")
+			model.ForwardFor = types.BoolValue(false)
 			return model
 		}(),
 		"negative max connections": func() haproxyFrontendModel {


### PR DESCRIPTION
## Summary

- Clears stale HTTP-only frontend fields when switching a frontend from `http` to `tcp` and Terraform leaves Optional+Computed values unknown.
- Rejects explicit `forwardfor` values for TCP frontends consistently.
- Corrects frontend name schema text to match the single-character-name behavior already implemented.

## Validation

- `go test ./...`
- `make lint`
- `git diff --check`
- `terraform fmt -check -recursive .`

Closes #37