### PR TITLE
M5-03 Add import coverage guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ terraform import pfsense_haproxy_settings.global settings
 - Delete removes Terraform state only.
 - Import uses the fixed ID `apply`.
 
+Import example:
+
+```bash
+terraform import pfsense_haproxy_apply.global apply
+```
+
 Example:
 
 ```hcl
@@ -477,6 +483,11 @@ make testacc
 ```
 
 `make testacc` requires real pfSense credentials and must be run only against an approved test target unless the issue explicitly targets production.
+
+Import coverage is intentionally all-or-nothing for implemented resources:
+every registered resource implements Terraform import state, has a documented
+`terraform import` command, and has unit coverage for its import ID parser.
+Registered data sources are lookup-only and cannot be imported.
 
 ## Resources
 

--- a/docs/schema/resource-schema-decisions.md
+++ b/docs/schema/resource-schema-decisions.md
@@ -29,6 +29,10 @@ Primary references:
 - Model HAProxy apply as an explicit action resource and read-only status data
   source. Do not add auto-apply flags to settings or durable resources unless a
   later issue intentionally changes that contract.
+- Maintain import coverage for every implemented resource. M5-03 audited all
+  registered resources as implementing Terraform import state with documented
+  import syntax and unit coverage; no implemented resource is intentionally
+  missing import support. Data sources are lookup-only and are not importable.
 - Mark actual secret-bearing attributes as sensitive when implemented. Public
   schema names include `stats_password`, `HAProxyFile.content`, certificate or
   private-key bodies, and custom/advanced HAProxy text fields that may carry

--- a/internal/provider/haproxy_settings_test.go
+++ b/internal/provider/haproxy_settings_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -71,6 +73,62 @@ func TestProviderRegistersHaproxySettings(t *testing.T) {
 	}
 	if !dataSourceTypeRegistered(dataSources, "pfsense_haproxy_settings") {
 		t.Fatalf("pfsense_haproxy_settings data source was not registered")
+	}
+}
+
+func TestImplementedResourcesHaveImportCoverage(t *testing.T) {
+	provider := &haproxyProvider{}
+	resourceByType := map[string]resource.Resource{}
+
+	for _, constructor := range provider.Resources(context.Background()) {
+		res := constructor()
+		var metadata resource.MetadataResponse
+		res.Metadata(context.Background(), resource.MetadataRequest{}, &metadata)
+		if metadata.TypeName == "" {
+			t.Fatalf("registered resource %T did not report a type name", res)
+		}
+		if _, exists := resourceByType[metadata.TypeName]; exists {
+			t.Fatalf("duplicate resource registration for %s", metadata.TypeName)
+		}
+		resourceByType[metadata.TypeName] = res
+	}
+
+	readme, err := os.ReadFile("../../README.md")
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	readmeText := string(readme)
+
+	expectedImportableResources := []string{
+		"pfsense_haproxy_apply",
+		"pfsense_haproxy_backend",
+		"pfsense_haproxy_backend_acl",
+		"pfsense_haproxy_backend_action",
+		"pfsense_haproxy_backend_server",
+		"pfsense_haproxy_frontend",
+		"pfsense_haproxy_frontend_acl",
+		"pfsense_haproxy_frontend_action",
+		"pfsense_haproxy_frontend_address",
+		"pfsense_haproxy_frontend_certificate",
+		"pfsense_haproxy_settings",
+	}
+
+	for _, typeName := range expectedImportableResources {
+		res, ok := resourceByType[typeName]
+		if !ok {
+			t.Fatalf("%s resource was not registered", typeName)
+		}
+		if _, ok := res.(resource.ResourceWithImportState); !ok {
+			t.Fatalf("%s does not implement ResourceWithImportState", typeName)
+		}
+		if !strings.Contains(readmeText, "terraform import "+typeName) {
+			t.Fatalf("README.md does not document terraform import syntax for %s", typeName)
+		}
+		delete(resourceByType, typeName)
+	}
+
+	for typeName := range resourceByType {
+		t.Fatalf("%s is registered without import coverage expectations", typeName)
 	}
 }
 

--- a/internal/provider/haproxy_settings_test.go
+++ b/internal/provider/haproxy_settings_test.go
@@ -99,21 +99,21 @@ func TestImplementedResourcesHaveImportCoverage(t *testing.T) {
 	}
 	readmeText := string(readme)
 
-	expectedImportableResources := []string{
-		"pfsense_haproxy_apply",
-		"pfsense_haproxy_backend",
-		"pfsense_haproxy_backend_acl",
-		"pfsense_haproxy_backend_action",
-		"pfsense_haproxy_backend_server",
-		"pfsense_haproxy_frontend",
-		"pfsense_haproxy_frontend_acl",
-		"pfsense_haproxy_frontend_action",
-		"pfsense_haproxy_frontend_address",
-		"pfsense_haproxy_frontend_certificate",
-		"pfsense_haproxy_settings",
+	expectedImportExamples := map[string]string{
+		"pfsense_haproxy_apply":                "terraform import pfsense_haproxy_apply.global apply",
+		"pfsense_haproxy_backend":              "terraform import pfsense_haproxy_backend.app app_backend",
+		"pfsense_haproxy_backend_acl":          "terraform import pfsense_haproxy_backend_acl.host app_backend/host_acl",
+		"pfsense_haproxy_backend_action":       "terraform import pfsense_haproxy_backend_action.route app_backend/route_app01",
+		"pfsense_haproxy_backend_server":       "terraform import pfsense_haproxy_backend_server.app app_backend/app01",
+		"pfsense_haproxy_frontend":             "terraform import pfsense_haproxy_frontend.app app_frontend",
+		"pfsense_haproxy_frontend_acl":         "terraform import pfsense_haproxy_frontend_acl.host app_frontend/host_acl",
+		"pfsense_haproxy_frontend_action":      "terraform import pfsense_haproxy_frontend_action.route app_frontend/route_app",
+		"pfsense_haproxy_frontend_address":     "terraform import pfsense_haproxy_frontend_address.app app_frontend/any_ipv4/-/443",
+		"pfsense_haproxy_frontend_certificate": "terraform import pfsense_haproxy_frontend_certificate.app app_frontend/existing_cert_ref",
+		"pfsense_haproxy_settings":             "terraform import pfsense_haproxy_settings.global settings",
 	}
 
-	for _, typeName := range expectedImportableResources {
+	for typeName, importExample := range expectedImportExamples {
 		res, ok := resourceByType[typeName]
 		if !ok {
 			t.Fatalf("%s resource was not registered", typeName)
@@ -121,8 +121,8 @@ func TestImplementedResourcesHaveImportCoverage(t *testing.T) {
 		if _, ok := res.(resource.ResourceWithImportState); !ok {
 			t.Fatalf("%s does not implement ResourceWithImportState", typeName)
 		}
-		if !strings.Contains(readmeText, "terraform import "+typeName+".") {
-			t.Fatalf("README.md does not document terraform import syntax for %s", typeName)
+		if !strings.Contains(readmeText, importExample) {
+			t.Fatalf("README.md does not document expected import example for %s: %s", typeName, importExample)
 		}
 		delete(resourceByType, typeName)
 	}

--- a/internal/provider/haproxy_settings_test.go
+++ b/internal/provider/haproxy_settings_test.go
@@ -121,7 +121,7 @@ func TestImplementedResourcesHaveImportCoverage(t *testing.T) {
 		if _, ok := res.(resource.ResourceWithImportState); !ok {
 			t.Fatalf("%s does not implement ResourceWithImportState", typeName)
 		}
-		if !strings.Contains(readmeText, "terraform import "+typeName) {
+		if !strings.Contains(readmeText, "terraform import "+typeName+".") {
 			t.Fatalf("README.md does not document terraform import syntax for %s", typeName)
 		}
 		delete(resourceByType, typeName)


### PR DESCRIPTION
## Summary
- add a provider-level import coverage guardrail for all registered resources
- document the missing apply import command and all-or-nothing import coverage policy
- record the M5-03 import audit in schema decisions

Fixes #17

## Validation
- go test ./...
- make lint
- terraform fmt -check -recursive .
- git diff --check