### PR TITLE
M6-02 Add PROD read-only validation lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,15 @@ jobs:
         with:
           name: coverage
           path: coverage.out
+
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: helper script tests
+        run: |
+          set -euo pipefail
+          python3 -m unittest scripts/capture_haproxy_schema_test.py scripts/prod_readonly_validate_test.py

--- a/.github/workflows/prod-readonly-validation.yml
+++ b/.github/workflows/prod-readonly-validation.yml
@@ -1,0 +1,73 @@
+name: prod-readonly-validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: "Type READ_ONLY_PROD_VALIDATION to run GET-only PROD discovery"
+        required: true
+        type: string
+
+jobs:
+  prod-readonly-validation:
+    if: ${{ github.repository_owner == 'd3vi1' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    environment: production-readonly
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: read-only safety precheck
+        env:
+          PFSENSE_ENDPOINT: ${{ secrets.PFSENSE_PROD_ENDPOINT }}
+          PFSENSE_API_KEY: ${{ secrets.PFSENSE_PROD_API_KEY }}
+          PFSENSE_USERNAME: ${{ secrets.PFSENSE_PROD_USERNAME }}
+          PFSENSE_PASSWORD: ${{ secrets.PFSENSE_PROD_PASSWORD }}
+          PFSENSE_VALIDATION_ENVIRONMENT: prod
+          PFSENSE_READONLY_CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::prod read-only validation must run from main"
+            exit 1
+          fi
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+            echo "::error::checked out code must match origin/main"
+            exit 1
+          fi
+          if [ "${PFSENSE_READONLY_CONFIRMATION}" != "READ_ONLY_PROD_VALIDATION" ]; then
+            echo "::error::confirmation must be READ_ONLY_PROD_VALIDATION"
+            exit 1
+          fi
+          if [ "${PFSENSE_VALIDATION_ENVIRONMENT}" != "prod" ]; then
+            echo "::error::PFSENSE_VALIDATION_ENVIRONMENT must be prod"
+            exit 1
+          fi
+          if [ -z "${PFSENSE_ENDPOINT}" ]; then
+            echo "::error::PFSENSE_PROD_ENDPOINT secret is required"
+            exit 1
+          fi
+          if [ -z "${PFSENSE_API_KEY}" ] && { [ -z "${PFSENSE_USERNAME}" ] || [ -z "${PFSENSE_PASSWORD}" ]; }; then
+            echo "::error::PFSENSE_PROD_API_KEY or PFSENSE_PROD_USERNAME/PFSENSE_PROD_PASSWORD is required"
+            exit 1
+          fi
+      - name: GET-only HAProxy discovery
+        env:
+          PFSENSE_ENDPOINT: ${{ secrets.PFSENSE_PROD_ENDPOINT }}
+          PFSENSE_API_KEY: ${{ secrets.PFSENSE_PROD_API_KEY }}
+          PFSENSE_USERNAME: ${{ secrets.PFSENSE_PROD_USERNAME }}
+          PFSENSE_PASSWORD: ${{ secrets.PFSENSE_PROD_PASSWORD }}
+          PFSENSE_INSECURE_TLS: ${{ secrets.PFSENSE_PROD_INSECURE_TLS }}
+          PFSENSE_TIMEOUT: ${{ secrets.PFSENSE_PROD_TIMEOUT }}
+          PFSENSE_VALIDATION_ENVIRONMENT: prod
+          PFSENSE_READONLY_CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          python3 scripts/prod_readonly_validate.py --output-dir validation-evidence/prod-readonly
+          echo "PROD read-only validation completed. Evidence remains on the ephemeral runner and is not uploaded from this public repository."

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ docs/fixtures/raw/
 docs/schema/**/*.raw.json
 docs/fixtures/**/*.raw.json
 *.unredacted.json
+validation-evidence/
 
 # Editor/OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -703,6 +703,9 @@ HAProxy endpoint inventory and provisional resource schema decisions are tracked
 under `docs/schema/`. M6 issue #18 UAT closeout evidence, including the
 acceptance runbook and endpoint response shape ledger, is tracked in
 [`docs/schema/m6-uat-acceptance-evidence.md`](docs/schema/m6-uat-acceptance-evidence.md).
+M6 issue #19 production read-only validation workflow and evidence format are
+tracked in
+[`docs/schema/m6-prod-readonly-validation.md`](docs/schema/m6-prod-readonly-validation.md).
 Live schema captures must be generated with:
 
 ```bash

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -77,6 +77,11 @@ endpoint response shape evidence ledger are tracked in
 is a template for the approved UAT run and does not claim live UAT execution
 from this environment.
 
+M6 issue #19 production read-only validation workflow, safety contract, and
+evidence format are tracked in
+[`m6-prod-readonly-validation.md`](m6-prod-readonly-validation.md). That lane
+uses only GET requests and explicitly forbids production apply/write steps.
+
 For M2-01, `pfsense_haproxy_settings` uses the upstream
 `HAProxySettings.inc` scalar model as a conservative implementation reference:
 Terraform manages only scalar fields, treats `advanced` as sensitive, and does

--- a/docs/schema/m6-prod-readonly-validation.md
+++ b/docs/schema/m6-prod-readonly-validation.md
@@ -1,0 +1,152 @@
+# M6 PROD Read-Only Validation Lane
+
+Status: issue #19 runbook and evidence format. This lane is intentionally
+read-only. It must not run `terraform apply`, `make testacc`, `go test -tags=acc`,
+or `POST /services/haproxy/apply` against production.
+
+## Safety Contract
+
+- `PFSENSE_VALIDATION_ENVIRONMENT` must be exactly `prod`.
+- `PFSENSE_READONLY_CONFIRMATION` must be exactly
+  `READ_ONLY_PROD_VALIDATION`.
+- The default workflow and script use only HTTP `GET`.
+- The workflow runs only from `main`, checks out `main`, uses the protected
+  `production-readonly` GitHub environment, and scopes production secrets only
+  to the precheck/discovery steps.
+- Evidence is shape/count/status only by default and is written under ignored
+  `validation-evidence/` paths for local runs. The public GitHub workflow does
+  not upload production evidence artifacts. It must not include full production
+  HAProxy payloads.
+- Production write/import/apply work requires a separate issue, an approved
+  operator window, and explicit confirmation. This lane does not provide that
+  path.
+
+## Manual Workflow
+
+Run the `prod-readonly-validation` GitHub Actions workflow manually and type:
+
+```text
+READ_ONLY_PROD_VALIDATION
+```
+
+The workflow maps only production-specific secrets into the script:
+
+- `PFSENSE_PROD_ENDPOINT`
+- `PFSENSE_PROD_API_KEY`, or `PFSENSE_PROD_USERNAME` and
+  `PFSENSE_PROD_PASSWORD`
+- `PFSENSE_PROD_INSECURE_TLS`
+- `PFSENSE_PROD_TIMEOUT`
+
+The public repository workflow does not upload evidence artifacts. Local runs
+write:
+
+- `discovery-shapes.redacted.json`
+- `evidence-summary.md`
+
+## Local Read-Only Discovery
+
+```bash
+export PFSENSE_ENDPOINT=https://pfsense-prod.example.com
+export PFSENSE_API_KEY=...
+export PFSENSE_VALIDATION_ENVIRONMENT=prod
+export PFSENSE_READONLY_CONFIRMATION=READ_ONLY_PROD_VALIDATION
+
+python3 scripts/prod_readonly_validate.py --output-dir validation-evidence/prod-readonly
+```
+
+Dry-run mode validates the gates and prints the static GET allowlist without
+network access:
+
+```bash
+python3 scripts/prod_readonly_validate.py --dry-run
+```
+
+The script reads only:
+
+- `GET /api/v2/schema/openapi`
+- `GET /api/v2/schema/native`
+- `GET /api/v2/services/haproxy/settings`
+- `GET /api/v2/services/haproxy/apply`
+- `GET /api/v2/services/haproxy/backends`
+- `GET /api/v2/services/haproxy/frontends`
+- child plural GET endpoints by discovered `parent_id`
+
+If any discovered backend or frontend lacks an `id`, `_id`, or `uuid`, the
+script fails instead of silently skipping child endpoint evidence.
+
+## Terraform Data-Source Plan Check
+
+The example in `examples/prod-readonly-validation/` contains data sources only.
+It is for read-only provider validation:
+
+```bash
+cd examples/prod-readonly-validation
+terraform init -backend=false
+terraform validate
+terraform plan -input=false -lock=false -detailed-exitcode -no-color
+```
+
+Allowed detailed-exitcode values:
+
+- `0`: no diff.
+- `2`: output values or refresh-derived changes are present; inspect but do not
+  apply.
+
+Exit code `1` is a failed validation and must be investigated before relying on
+the lane.
+
+## Import/Refresh Checklist
+
+Import validation is an operator checklist, not part of the default workflow.
+It writes only local scratch Terraform state and performs provider reads:
+
+```bash
+mkdir -p .local-secrets/prod-import-check
+cp examples/prod-readonly-validation/main.tf .local-secrets/prod-import-check/main.tf
+cd .local-secrets/prod-import-check
+
+export TF_VAR_pfsense_endpoint="${PFSENSE_ENDPOINT}"
+export TF_VAR_pfsense_api_key="${PFSENSE_API_KEY:-}"
+export TF_VAR_pfsense_username="${PFSENSE_USERNAME:-}"
+export TF_VAR_pfsense_password="${PFSENSE_PASSWORD:-}"
+export TF_VAR_pfsense_insecure_tls="${PFSENSE_INSECURE_TLS:-false}"
+export TF_VAR_pfsense_timeout="${PFSENSE_TIMEOUT:-30s}"
+
+terraform init -backend=false
+
+cat > imports.tf <<'HCL'
+resource "pfsense_haproxy_backend" "example" {
+  name = "<backend_name>"
+}
+
+resource "pfsense_haproxy_backend_server" "example" {
+  backend_name = "<backend_name>"
+  name         = "<server_name>"
+  address      = "127.0.0.1"
+  port         = 1
+}
+HCL
+
+terraform import pfsense_haproxy_backend.example '<backend_name>'
+terraform import pfsense_haproxy_backend_server.example '<backend_name>/<server_name>'
+
+terraform plan -refresh-only -input=false -lock=false -detailed-exitcode -no-color
+```
+
+Do not import or apply `pfsense_haproxy_apply` as a resource in production from
+this lane. Do not run `terraform apply`. The placeholder server `address` and
+`port` values above are only Terraform configuration stubs required before
+`terraform import`; `terraform plan -refresh-only` refreshes them from pfSense
+without proposing writes.
+
+## Evidence Summary
+
+Record the following before closing issue #19:
+
+- Date, operator, target marked as production, and commit tested.
+- Confirmation that the workflow/script used only GET requests.
+- Local evidence path or workflow run log reference. Do not upload production
+  evidence artifacts from the public repository workflow.
+- `terraform validate` and data-source-only plan result, if run.
+- Any drift or diagnostics observed, without committing production names,
+  addresses, certificates, tokens, or raw configuration.

--- a/examples/prod-readonly-validation/main.tf
+++ b/examples/prod-readonly-validation/main.tf
@@ -1,0 +1,85 @@
+terraform {
+  required_providers {
+    pfsense = {
+      source = "d3vi1/pfsense-restapi-haproxy"
+    }
+  }
+}
+
+provider "pfsense" {
+  endpoint     = var.pfsense_endpoint
+  api_key      = var.pfsense_api_key
+  username     = var.pfsense_username
+  password     = var.pfsense_password
+  insecure_tls = var.pfsense_insecure_tls
+  timeout      = var.pfsense_timeout
+}
+
+variable "pfsense_endpoint" {
+  type = string
+}
+
+variable "pfsense_api_key" {
+  type      = string
+  sensitive = true
+  default   = null
+}
+
+variable "pfsense_username" {
+  type      = string
+  sensitive = true
+  default   = null
+}
+
+variable "pfsense_password" {
+  type      = string
+  sensitive = true
+  default   = null
+}
+
+variable "pfsense_insecure_tls" {
+  type    = bool
+  default = false
+}
+
+variable "pfsense_timeout" {
+  type    = string
+  default = "30s"
+}
+
+variable "existing_backend_name" {
+  type        = string
+  description = "Existing production backend name to read. Leave null to skip backend data source validation."
+  default     = null
+}
+
+variable "existing_backend_server_name" {
+  type        = string
+  description = "Existing server name under existing_backend_name to read. Leave null to skip server validation."
+  default     = null
+}
+
+data "pfsense_haproxy_settings" "current" {}
+
+data "pfsense_haproxy_apply" "status" {}
+
+data "pfsense_haproxy_backend" "existing" {
+  count = var.existing_backend_name == null ? 0 : 1
+  name  = var.existing_backend_name
+}
+
+data "pfsense_haproxy_backend_server" "existing" {
+  count = var.existing_backend_name == null || var.existing_backend_server_name == null ? 0 : 1
+
+  backend_name = var.existing_backend_name
+  name         = var.existing_backend_server_name
+}
+
+output "readonly_haproxy_status" {
+  value = {
+    apply_status         = data.pfsense_haproxy_apply.status.status
+    settings_enabled     = data.pfsense_haproxy_settings.current.enable
+    backend_found        = length(data.pfsense_haproxy_backend.existing) > 0
+    backend_server_found = length(data.pfsense_haproxy_backend_server.existing) > 0
+  }
+}

--- a/scripts/prod_readonly_validate.py
+++ b/scripts/prod_readonly_validate.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Run a GET-only pfSense HAProxy production discovery lane.
+
+The script never calls Terraform and never sends write methods. It reads a
+small allowlist of schema, status, top-level, and child-list HAProxy endpoints,
+redacts values that may contain secrets, and writes private evidence artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import posixpath
+import re
+import ssl
+import sys
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+API_PREFIX = "/api/v2"
+READ_ONLY_CONFIRMATION = "READ_ONLY_PROD_VALIDATION"
+DEFAULT_OUTPUT_DIR = "validation-evidence/prod-readonly"
+REDACTION_TEXT = "[REDACTED]"
+
+STATIC_GET_PATHS = (
+    "/schema/openapi",
+    "/schema/native",
+    "/services/haproxy/settings",
+    "/services/haproxy/apply",
+    "/services/haproxy/backends",
+    "/services/haproxy/frontends",
+)
+CHILD_COLLECTIONS = (
+    "/services/haproxy/backend/servers",
+    "/services/haproxy/backend/acls",
+    "/services/haproxy/backend/actions",
+    "/services/haproxy/frontend/addresses",
+    "/services/haproxy/frontend/certificates",
+    "/services/haproxy/frontend/acls",
+    "/services/haproxy/frontend/actions",
+)
+SENSITIVE_KEY_RE = re.compile(
+    r"(^|[_-])(api[_-]?key|authorization|bearer|cert|certificate|client[_-]?cert|"
+    r"credential|jwt|key|p12|passwd|password|private[_-]?key|secret|token)([_-]|$)",
+    re.IGNORECASE,
+)
+PEM_RE = re.compile(r"-----BEGIN [A-Z0-9 ]+-----")
+PRIVATE_CONFIG_RE = re.compile(r"<(?:pfsense|config)[\s>]", re.IGNORECASE)
+LONG_TOKEN_RE = re.compile(r"^[A-Za-z0-9+/=_-]{80,}$")
+
+
+class MissingParentIDError(ValueError):
+    """Raised when child discovery cannot safely continue for a parent object."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="GET-only pfSense HAProxy production validation discovery."
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory for redacted evidence. Default: {DEFAULT_OUTPUT_DIR}.",
+    )
+    parser.add_argument(
+        "--timeout",
+        default=os.getenv("PFSENSE_TIMEOUT", "30s"),
+        help="HTTP timeout, for example 30s or 5.5. Default: PFSENSE_TIMEOUT or 30s.",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        default=parse_bool(os.getenv("PFSENSE_INSECURE_TLS", "")),
+        help="Skip TLS verification. Default: PFSENSE_INSECURE_TLS.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate gates and print planned GET paths without network access.",
+    )
+    return parser.parse_args()
+
+
+def parse_bool(raw: str) -> bool:
+    return raw.strip().lower() in {"1", "t", "true", "y", "yes", "on"}
+
+
+def parse_timeout(raw: str) -> float:
+    value = raw.strip().lower()
+    if not value:
+        return 30.0
+    multipliers = {"ms": 0.001, "s": 1.0, "m": 60.0}
+    for suffix, multiplier in multipliers.items():
+        if value.endswith(suffix):
+            return float(value[: -len(suffix)]) * multiplier
+    return float(value)
+
+
+def build_url(endpoint: str, request_path: str, query: dict[str, str] | None = None) -> str:
+    parsed = urllib.parse.urlparse(endpoint.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("PFSENSE_ENDPOINT must be an absolute http(s) URL")
+
+    base_path = parsed.path.rstrip("/")
+    api_path = "/" + request_path.lstrip("/")
+    if base_path.endswith(API_PREFIX) and api_path.startswith(API_PREFIX):
+        api_path = api_path[len(API_PREFIX) :] or "/"
+
+    if api_path.startswith(API_PREFIX):
+        joined_path = posixpath.join(base_path, api_path.lstrip("/"))
+    elif base_path.endswith(API_PREFIX):
+        joined_path = posixpath.join(base_path, api_path.lstrip("/"))
+    else:
+        joined_path = posixpath.join(base_path, API_PREFIX.lstrip("/"), api_path.lstrip("/"))
+
+    if not joined_path.startswith("/"):
+        joined_path = "/" + joined_path
+
+    encoded_query = urllib.parse.urlencode(query or {})
+    return urllib.parse.urlunparse(
+        parsed._replace(path=joined_path, params="", query=encoded_query, fragment="")
+    )
+
+
+def auth_headers() -> tuple[dict[str, str], str]:
+    api_key = os.getenv("PFSENSE_API_KEY", "").strip()
+    username = os.getenv("PFSENSE_USERNAME", "").strip()
+    password = os.getenv("PFSENSE_PASSWORD", "")
+
+    if api_key:
+        return {"X-API-Key": api_key}, "api_key"
+    if username and password:
+        token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+        return {"Authorization": f"Basic {token}"}, "basic"
+    return {}, "missing"
+
+
+def validate_prod_readonly_gate() -> None:
+    if os.getenv("PFSENSE_VALIDATION_ENVIRONMENT", "").strip().lower() != "prod":
+        raise ValueError("PFSENSE_VALIDATION_ENVIRONMENT must be prod")
+    if os.getenv("PFSENSE_READONLY_CONFIRMATION", "").strip() != READ_ONLY_CONFIRMATION:
+        raise ValueError(f"PFSENSE_READONLY_CONFIRMATION must be {READ_ONLY_CONFIRMATION}")
+    if not os.getenv("PFSENSE_ENDPOINT", "").strip():
+        raise ValueError("PFSENSE_ENDPOINT is required")
+    _, auth_mode = auth_headers()
+    if auth_mode == "missing":
+        raise ValueError("PFSENSE_API_KEY or PFSENSE_USERNAME/PFSENSE_PASSWORD is required")
+
+
+def fetch_json(url: str, headers: dict[str, str], insecure: bool, timeout: float) -> Any:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "terraform-provider-pfsense-restapi-haproxy-prod-readonly",
+            **headers,
+        },
+        method="GET",
+    )
+    context = ssl._create_unverified_context() if insecure else None
+    with urllib.request.urlopen(request, timeout=timeout, context=context) as response:
+        body = response.read()
+    return json.loads(body)
+
+
+def response_shape(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        items = extract_items(value)
+        return {
+            "type": "object",
+            "keys": sorted(str(key) for key in value.keys()),
+            "item_count": len(items),
+            "item_keys": sorted({str(key) for item in items for key in item.keys()}),
+        }
+    if isinstance(value, list):
+        items = [item for item in value if isinstance(item, dict)]
+        return {
+            "type": "array",
+            "item_count": len(items),
+            "item_keys": sorted({str(key) for item in items for key in item.keys()}),
+        }
+    return {"type": type(value).__name__}
+
+
+def extract_items(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if not isinstance(payload, dict):
+        return []
+    for key in ("data", "items", "rows", "results"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [item for item in value if isinstance(item, dict)]
+        if isinstance(value, dict):
+            return [value]
+    return []
+
+
+def object_id(item: dict[str, Any]) -> str | None:
+    for key in ("id", "_id", "uuid"):
+        value = item.get(key)
+        if value is not None and str(value).strip():
+            return str(value)
+    return None
+
+
+def redact(value: Any, parent_sensitive: bool = False) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            sensitive = parent_sensitive or bool(SENSITIVE_KEY_RE.search(str(key)))
+            redacted[key] = redact(item, sensitive)
+        return redacted
+    if isinstance(value, list):
+        return [redact(item, parent_sensitive) for item in value]
+    if isinstance(value, str):
+        if parent_sensitive or PEM_RE.search(value) or PRIVATE_CONFIG_RE.search(value):
+            return REDACTION_TEXT
+        if LONG_TOKEN_RE.match(value.strip()):
+            return REDACTION_TEXT
+    return value
+
+
+def collect_paths(discovered: dict[str, Any]) -> list[dict[str, Any]]:
+    requests: list[dict[str, Any]] = [{"path": path, "query": {}} for path in STATIC_GET_PATHS]
+
+    for backend in extract_items(discovered.get("/services/haproxy/backends")):
+        parent_id = object_id(backend)
+        if not parent_id:
+            raise MissingParentIDError("backend object is missing id/_id/uuid for child discovery")
+        for child_path in CHILD_COLLECTIONS[:3]:
+            requests.append({"path": child_path, "query": {"parent_id": parent_id}})
+
+    for frontend in extract_items(discovered.get("/services/haproxy/frontends")):
+        parent_id = object_id(frontend)
+        if not parent_id:
+            raise MissingParentIDError("frontend object is missing id/_id/uuid for child discovery")
+        for child_path in CHILD_COLLECTIONS[3:]:
+            requests.append({"path": child_path, "query": {"parent_id": parent_id}})
+
+    return requests
+
+
+def write_evidence(output_dir: Path, discovered: dict[str, Any], requests: list[dict[str, Any]]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "mode": "prod-readonly",
+        "write_methods_used": [],
+        "request_count": len(requests),
+        "paths": redact_requests(requests),
+    }
+    shapes = {redact_response_key(path): response_shape(payload) for path, payload in discovered.items()}
+    (output_dir / "discovery-shapes.redacted.json").write_text(
+        json.dumps({"summary": summary, "response_shapes": redact(shapes)}, indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "evidence-summary.md").write_text(render_summary(summary), encoding="utf-8")
+
+
+def render_summary(summary: dict[str, Any]) -> str:
+    lines = [
+        "# PROD Read-Only HAProxy Validation Evidence",
+        "",
+        f"- Generated at UTC: `{summary['generated_at_utc']}`",
+        "- Mode: `prod-readonly`",
+        "- Write methods used: none",
+        f"- GET requests attempted: `{summary['request_count']}`",
+        "",
+        "## Requests",
+        "",
+    ]
+    for request in summary["paths"]:
+        query = request["query"]
+        suffix = f"?{urllib.parse.urlencode(query)}" if query else ""
+        lines.append(f"- `GET {request['path']}{suffix}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def redact_requests(requests: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    redacted: list[dict[str, Any]] = []
+    for request in requests:
+        redacted.append(
+            {
+                "path": request["path"],
+                "query": {key: "[present]" for key in sorted(request["query"].keys())},
+            }
+        )
+    return redacted
+
+
+def redact_response_key(key: str) -> str:
+    parsed = urllib.parse.urlparse(key)
+    if not parsed.query:
+        return key
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    redacted_query = urllib.parse.urlencode([(name, "[present]") for name, _ in query])
+    return urllib.parse.urlunparse(parsed._replace(query=redacted_query))
+
+
+def run(args: argparse.Namespace) -> int:
+    try:
+        validate_prod_readonly_gate()
+        timeout = parse_timeout(args.timeout)
+        build_url(os.environ["PFSENSE_ENDPOINT"], STATIC_GET_PATHS[0])
+    except ValueError as exc:
+        print(f"prod-readonly validation error: {exc}", file=sys.stderr)
+        return 2
+
+    planned = [{"path": path, "query": {}} for path in STATIC_GET_PATHS]
+    if args.dry_run:
+        print(json.dumps({"mode": "dry-run", "requests": planned}, indent=2, sort_keys=True))
+        return 0
+
+    headers, _ = auth_headers()
+    discovered: dict[str, Any] = {}
+    for request in planned:
+        path = request["path"]
+        discovered[path] = fetch_json(
+            build_url(os.environ["PFSENSE_ENDPOINT"], path),
+            headers,
+            args.insecure,
+            timeout,
+        )
+
+    try:
+        requests = collect_paths(discovered)
+    except MissingParentIDError as exc:
+        print(f"prod-readonly validation error: {exc}", file=sys.stderr)
+        return 3
+    for request in requests[len(planned) :]:
+        discovered[f"{request['path']}?{urllib.parse.urlencode(request['query'])}"] = fetch_json(
+            build_url(os.environ["PFSENSE_ENDPOINT"], request["path"], request["query"]),
+            headers,
+            args.insecure,
+            timeout,
+        )
+
+    write_evidence(Path(args.output_dir), discovered, requests)
+    return 0
+
+
+def main() -> int:
+    return run(parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prod_readonly_validate_test.py
+++ b/scripts/prod_readonly_validate_test.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Unit tests for prod_readonly_validate.py safety behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import argparse
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("prod_readonly_validate.py")
+SPEC = importlib.util.spec_from_file_location("prod_readonly_validate", SCRIPT_PATH)
+assert SPEC is not None
+prod_readonly_validate = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(prod_readonly_validate)
+
+
+class GateTests(unittest.TestCase):
+    def test_dry_run_requires_prod_confirmation(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--dry-run"],
+            check=False,
+            env={
+                "PFSENSE_ENDPOINT": "https://pfsense.example.com",
+                "PFSENSE_API_KEY": "secret",
+                "PFSENSE_VALIDATION_ENVIRONMENT": "uat",
+                "PFSENSE_READONLY_CONFIRMATION": "READ_ONLY_PROD_VALIDATION",
+            },
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("PFSENSE_VALIDATION_ENVIRONMENT must be prod", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_dry_run_lists_only_static_get_paths(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--dry-run"],
+            check=False,
+            env={
+                "PFSENSE_ENDPOINT": "https://pfsense.example.com",
+                "PFSENSE_API_KEY": "secret",
+                "PFSENSE_VALIDATION_ENVIRONMENT": "prod",
+                "PFSENSE_READONLY_CONFIRMATION": "READ_ONLY_PROD_VALIDATION",
+            },
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("/services/haproxy/backends", result.stdout)
+        self.assertNotIn("POST", result.stdout)
+        self.assertNotIn("DELETE", result.stdout)
+
+
+class DiscoveryTests(unittest.TestCase):
+    def test_collect_paths_adds_child_gets_by_parent_id(self) -> None:
+        discovered = {
+            "/services/haproxy/backends": {"data": [{"id": "10", "name": "app"}]},
+            "/services/haproxy/frontends": {"data": [{"id": "20", "name": "web"}]},
+        }
+
+        requests = prod_readonly_validate.collect_paths(discovered)
+
+        self.assertIn(
+            {"path": "/services/haproxy/backend/servers", "query": {"parent_id": "10"}},
+            requests,
+        )
+        self.assertIn(
+            {"path": "/services/haproxy/frontend/actions", "query": {"parent_id": "20"}},
+            requests,
+        )
+
+    def test_collect_paths_handles_singleton_parent_payloads(self) -> None:
+        discovered = {
+            "/services/haproxy/backends": {"data": {"id": "10", "name": "app"}},
+            "/services/haproxy/frontends": {"data": {"id": "20", "name": "web"}},
+        }
+
+        requests = prod_readonly_validate.collect_paths(discovered)
+
+        self.assertIn(
+            {"path": "/services/haproxy/backend/actions", "query": {"parent_id": "10"}},
+            requests,
+        )
+        self.assertIn(
+            {"path": "/services/haproxy/frontend/certificates", "query": {"parent_id": "20"}},
+            requests,
+        )
+
+    def test_singleton_parent_without_id_fails(self) -> None:
+        discovered = {
+            "/services/haproxy/backends": {"data": {"name": "app"}},
+            "/services/haproxy/frontends": {"data": []},
+        }
+
+        with self.assertRaises(prod_readonly_validate.MissingParentIDError):
+            prod_readonly_validate.collect_paths(discovered)
+
+    def test_redact_requests_hides_parent_id_values(self) -> None:
+        redacted = prod_readonly_validate.redact_requests(
+            [{"path": "/services/haproxy/backend/servers", "query": {"parent_id": "10"}}]
+        )
+
+        self.assertEqual(
+            redacted,
+            [{"path": "/services/haproxy/backend/servers", "query": {"parent_id": "[present]"}}],
+        )
+        self.assertNotIn("10", repr(redacted))
+
+    def test_redact_response_key_hides_parent_id_values(self) -> None:
+        key = prod_readonly_validate.redact_response_key(
+            "/services/haproxy/backend/servers?parent_id=10"
+        )
+
+        self.assertEqual(key, "/services/haproxy/backend/servers?parent_id=%5Bpresent%5D")
+        self.assertNotIn("10", key)
+
+    def test_runtime_uses_get_only_requests(self) -> None:
+        responses = {
+            "/api/v2/schema/openapi": {},
+            "/api/v2/schema/native": {},
+            "/api/v2/services/haproxy/settings": {"data": {}},
+            "/api/v2/services/haproxy/apply": {"data": {"applied": True}},
+            "/api/v2/services/haproxy/backends": {"data": [{"id": "10", "name": "app"}]},
+            "/api/v2/services/haproxy/frontends": {"data": []},
+            "/api/v2/services/haproxy/backend/servers": {"data": []},
+            "/api/v2/services/haproxy/backend/acls": {"data": []},
+            "/api/v2/services/haproxy/backend/actions": {"data": []},
+        }
+        requested_methods: list[str] = []
+
+        def fake_fetch(url: str, headers: dict[str, str], insecure: bool, timeout: float) -> object:
+            parsed = prod_readonly_validate.urllib.parse.urlparse(url)
+            requested_methods.append("GET")
+            return responses[parsed.path]
+
+        with tempfile.TemporaryDirectory() as tmpdir, mock.patch.dict(
+            os.environ,
+            {
+                "PFSENSE_ENDPOINT": "https://pfsense.example.com",
+                "PFSENSE_API_KEY": "secret",
+                "PFSENSE_VALIDATION_ENVIRONMENT": "prod",
+                "PFSENSE_READONLY_CONFIRMATION": "READ_ONLY_PROD_VALIDATION",
+            },
+            clear=True,
+        ), mock.patch.object(prod_readonly_validate, "fetch_json", side_effect=fake_fetch):
+            code = prod_readonly_validate.run(
+                argparse.Namespace(output_dir=tmpdir, timeout="30s", insecure=False, dry_run=False)
+            )
+
+        self.assertEqual(code, 0)
+        self.assertTrue(requested_methods)
+        self.assertEqual(set(requested_methods), {"GET"})
+
+    def test_fetch_json_constructs_get_request(self) -> None:
+        seen_methods: list[str] = []
+
+        class FakeResponse:
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return b"{}"
+
+        def fake_urlopen(request: object, timeout: float, context: object = None) -> FakeResponse:
+            seen_methods.append(request.get_method())
+            return FakeResponse()
+
+        with mock.patch.object(prod_readonly_validate.urllib.request, "urlopen", side_effect=fake_urlopen):
+            prod_readonly_validate.fetch_json(
+                "https://pfsense.example.com/api/v2/services/haproxy/settings",
+                {},
+                False,
+                30,
+            )
+
+        self.assertEqual(seen_methods, ["GET"])
+
+    def test_collect_paths_fails_when_parent_id_missing(self) -> None:
+        discovered = {
+            "/services/haproxy/backends": {"data": [{"name": "app"}]},
+            "/services/haproxy/frontends": {"data": []},
+        }
+
+        with self.assertRaises(prod_readonly_validate.MissingParentIDError):
+            prod_readonly_validate.collect_paths(discovered)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a GET-only production HAProxy discovery script with strict `prod` and confirmation gates.
- Add a manual `prod-readonly-validation` workflow that runs only from `main`, uses the protected `production-readonly` environment, scopes production secrets to the precheck/discovery steps, and does not upload production evidence artifacts from this public repo.
- Add a data-source-only Terraform validation example and runbook/evidence format for issue #19.
- Wire Python helper script tests into CI.

## Safety
- No live PROD validation was run from this environment.
- The script uses only HTTP GET and writes shape-only evidence under ignored `validation-evidence/` paths for local runs.
- The workflow requires `READ_ONLY_PROD_VALIDATION` and production-specific secrets.
- `terraform apply`, `make testacc`, and `go test -tags=acc` are explicitly forbidden in the runbook for this lane.

## Validation
- `python3 -m unittest scripts/capture_haproxy_schema_test.py scripts/prod_readonly_validate_test.py`
- `PFSENSE_ENDPOINT=https://pfsense.example.com PFSENSE_API_KEY=secret PFSENSE_VALIDATION_ENVIRONMENT=prod PFSENSE_READONLY_CONFIRMATION=READ_ONLY_PROD_VALIDATION python3 scripts/prod_readonly_validate.py --dry-run`
- `terraform fmt -check -recursive examples/prod-readonly-validation`
- `go test ./...`
- `make lint`
- `git diff --check`

Refs #19