### PR TITLE
Harden REST client retry diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Prefer API key authentication for automation.
 modeled explicitly by `pfsense_haproxy_apply`; settings and other durable
 resources do not trigger hidden reloads.
 
+The REST client retries only safe reads. `GET` requests are retried once for
+transient transport failures and HTTP/API-envelope `408`, `429`, `500`, `502`,
+`503`, and `504` responses, honoring `Retry-After` up to a bounded delay.
+Mutating `POST`, `PATCH`, `PUT`, and `DELETE` requests are never replayed
+automatically; transient write failures include diagnostics telling operators
+to refresh or inspect live pfSense HAProxy state before rerunning Terraform.
+
 ## HAProxy settings ownership
 
 `pfsense_haproxy_settings` is split into a data source and a singleton resource:

--- a/internal/pfsense/client.go
+++ b/internal/pfsense/client.go
@@ -210,7 +210,7 @@ func (c *Client) doWithRetry(ctx context.Context, method string, requestURL stri
 		class := classifyFailure(err)
 		if shouldRetryRequest(ctx, method, class, attempt) {
 			if waitErr := waitBeforeRetry(ctx, retryDelay(err)); waitErr != nil {
-				return decorateRequestError(method, displayPath, fmt.Errorf("%w; safe GET retry wait canceled: %v", err, waitErr), class, retryAttempted, false)
+				return decorateRequestError(method, displayPath, fmt.Errorf("%w; safe GET retry wait canceled: %w", err, waitErr), class, retryAttempted, false)
 			}
 			retryAttempted = true
 			continue
@@ -258,7 +258,7 @@ func (c *Client) doOnce(ctx context.Context, method string, requestURL string, d
 
 	if envelope, ok := parseEnvelope(responseBody); ok {
 		if envelope.Code >= 400 {
-			return envelopeAPIError(resp.StatusCode, method, displayPath, responseBody, envelope)
+			return envelopeAPIError(resp.StatusCode, method, displayPath, responseBody, envelope, resp.Header.Get("Retry-After"))
 		}
 		if out == nil {
 			return nil
@@ -288,9 +288,6 @@ func classifyFailure(err error) failureClass {
 		return classifyStatusCode(apiErr.StatusCode)
 	}
 
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return failureClassPermanent
-	}
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		return failureClassTransient
@@ -300,6 +297,9 @@ func classifyFailure(err error) failureClass {
 	}
 	if errors.As(err, &temporaryErr) && temporaryErr.Temporary() {
 		return failureClassTransient
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return failureClassPermanent
 	}
 
 	return failureClassPermanent
@@ -497,7 +497,7 @@ func newAPIError(resp *http.Response, method string, path string) error {
 	message := statusGuidance(resp.StatusCode)
 	envelope, hasEnvelope := parseEnvelope(bodyBytes)
 	if hasEnvelope && envelope.Code >= 400 {
-		return envelopeAPIError(resp.StatusCode, method, path, bodyBytes, envelope)
+		return envelopeAPIError(resp.StatusCode, method, path, bodyBytes, envelope, resp.Header.Get("Retry-After"))
 	}
 	if detail := errorDetail(body); detail != "" {
 		message = message + ": " + detail
@@ -546,7 +546,7 @@ func parseEnvelope(body []byte) (responseEnvelope, bool) {
 	return envelope, true
 }
 
-func envelopeAPIError(statusCode int, method string, path string, body []byte, envelope responseEnvelope) error {
+func envelopeAPIError(statusCode int, method string, path string, body []byte, envelope responseEnvelope, retryAfter string) error {
 	effectiveStatusCode := statusCode
 	if envelope.Code >= 400 {
 		effectiveStatusCode = envelope.Code
@@ -568,6 +568,7 @@ func envelopeAPIError(statusCode int, method string, path string, body []byte, e
 		ResponseID: envelope.ResponseID,
 		Message:    message,
 		Body:       strings.TrimSpace(string(body)),
+		RetryAfter: retryAfter,
 	}
 }
 

--- a/internal/pfsense/client.go
+++ b/internal/pfsense/client.go
@@ -8,14 +8,22 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	pathpkg "path"
+	"strconv"
 	"strings"
 	"time"
 )
 
 const apiPathPrefix = "/api/v2"
+
+const (
+	maxSafeReadRetries = 1
+	defaultRetryDelay  = 100 * time.Millisecond
+	maxRetryDelay      = 2 * time.Second
+)
 
 // configWriteGuard serializes pfSense config mutations within one provider process.
 var configWriteGuard = make(chan struct{}, 1)
@@ -48,6 +56,50 @@ type APIError struct {
 	ResponseID string
 	Message    string
 	Body       string
+	RetryAfter string
+}
+
+type failureClass string
+
+const (
+	failureClassPermanent    failureClass = "permanent"
+	failureClassTransient    failureClass = "transient"
+	failureClassUnclassified failureClass = "unclassified"
+)
+
+type classifiedRequestError struct {
+	err            error
+	class          failureClass
+	method         string
+	path           string
+	retryAttempted bool
+	retryable      bool
+}
+
+func (e *classifiedRequestError) Error() string {
+	message := e.err.Error()
+	switch e.class {
+	case failureClassTransient:
+		message += ". Classified as transient"
+	case failureClassPermanent:
+		message += ". Classified as permanent"
+	default:
+		message += ". Failure class is unclassified"
+	}
+	if e.retryAttempted {
+		message += "; a safe GET retry was attempted"
+	} else if e.retryable {
+		message += "; safe GET retry was available but was not attempted"
+	} else if isConfigMutationMethod(e.method) {
+		message += "; unsafe config write was not retried automatically. Refresh or inspect live pfSense HAProxy state before rerunning Terraform"
+	} else {
+		message += "; request was not retried"
+	}
+	return message
+}
+
+func (e *classifiedRequestError) Unwrap() error {
+	return e.err
 }
 
 func (e *APIError) Error() string {
@@ -133,13 +185,45 @@ func (c *Client) Do(ctx context.Context, method string, path string, in any, out
 		return err
 	}
 
-	var body io.Reader
+	var bodyBytes []byte
 	if in != nil {
 		encoded, err := json.Marshal(in)
 		if err != nil {
 			return fmt.Errorf("encode %s %s request: %w", method, displayPath, err)
 		}
-		body = bytes.NewReader(encoded)
+		bodyBytes = encoded
+	}
+
+	return withConfigWriteGuard(ctx, method, func() error {
+		return c.doWithRetry(ctx, method, requestURL, displayPath, bodyBytes, in != nil, out)
+	})
+}
+
+func (c *Client) doWithRetry(ctx context.Context, method string, requestURL string, displayPath string, bodyBytes []byte, hasBody bool, out any) error {
+	retryAttempted := false
+	for attempt := 0; ; attempt++ {
+		err := c.doOnce(ctx, method, requestURL, displayPath, bodyBytes, hasBody, out)
+		if err == nil {
+			return nil
+		}
+
+		class := classifyFailure(err)
+		if shouldRetryRequest(ctx, method, class, attempt) {
+			if waitErr := waitBeforeRetry(ctx, retryDelay(err)); waitErr != nil {
+				return decorateRequestError(method, displayPath, fmt.Errorf("%w; safe GET retry wait canceled: %v", err, waitErr), class, retryAttempted, false)
+			}
+			retryAttempted = true
+			continue
+		}
+
+		return decorateRequestError(method, displayPath, err, class, retryAttempted, isRetryableRead(method, class))
+	}
+}
+
+func (c *Client) doOnce(ctx context.Context, method string, requestURL string, displayPath string, bodyBytes []byte, hasBody bool, out any) error {
+	var body io.Reader
+	if hasBody {
+		body = bytes.NewReader(bodyBytes)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, requestURL, body)
@@ -147,57 +231,163 @@ func (c *Client) Do(ctx context.Context, method string, path string, in any, out
 		return fmt.Errorf("create %s %s request: %w", method, displayPath, err)
 	}
 	req.Header.Set("Accept", "application/json")
-	if in != nil {
+	if hasBody {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	c.setAuth(req)
 
-	return withConfigWriteGuard(ctx, method, func() error {
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("%s %s request failed: %w", method, displayPath, err)
-		}
-		defer func() {
-			_ = resp.Body.Close()
-		}()
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s request failed: %w", method, displayPath, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
-		if resp.StatusCode < http.StatusOK || resp.StatusCode > 299 {
-			return newAPIError(resp, method, displayPath)
-		}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode > 299 {
+		return newAPIError(resp, method, displayPath)
+	}
 
-		responseBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("read %s %s response: %w", method, displayPath, err)
-		}
-		if len(bytes.TrimSpace(responseBody)) == 0 {
-			return nil
-		}
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read %s %s response: %w", method, displayPath, err)
+	}
+	if len(bytes.TrimSpace(responseBody)) == 0 {
+		return nil
+	}
 
-		if envelope, ok := parseEnvelope(responseBody); ok {
-			if envelope.Code >= 400 {
-				return envelopeAPIError(resp.StatusCode, method, displayPath, responseBody, envelope)
-			}
-			if out == nil {
-				return nil
-			}
-			if len(envelope.Data) == 0 || string(envelope.Data) == "null" {
-				return nil
-			}
-			if err := json.Unmarshal(envelope.Data, out); err != nil {
-				return fmt.Errorf("decode %s %s response data: %w", method, displayPath, err)
-			}
-			return nil
+	if envelope, ok := parseEnvelope(responseBody); ok {
+		if envelope.Code >= 400 {
+			return envelopeAPIError(resp.StatusCode, method, displayPath, responseBody, envelope)
 		}
-
 		if out == nil {
 			return nil
 		}
-		if err := json.Unmarshal(responseBody, out); err != nil {
-			return fmt.Errorf("decode %s %s response: %w", method, displayPath, err)
+		if len(envelope.Data) == 0 || string(envelope.Data) == "null" {
+			return nil
 		}
-
+		if err := json.Unmarshal(envelope.Data, out); err != nil {
+			return fmt.Errorf("decode %s %s response data: %w", method, displayPath, err)
+		}
 		return nil
-	})
+	}
+
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(responseBody, out); err != nil {
+		return fmt.Errorf("decode %s %s response: %w", method, displayPath, err)
+	}
+
+	return nil
+}
+
+func classifyFailure(err error) failureClass {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return classifyStatusCode(apiErr.StatusCode)
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return failureClassPermanent
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return failureClassTransient
+	}
+	var temporaryErr interface {
+		Temporary() bool
+	}
+	if errors.As(err, &temporaryErr) && temporaryErr.Temporary() {
+		return failureClassTransient
+	}
+
+	return failureClassPermanent
+}
+
+func classifyStatusCode(statusCode int) failureClass {
+	switch statusCode {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return failureClassTransient
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict, http.StatusUnprocessableEntity:
+		return failureClassPermanent
+	default:
+		if statusCode >= 500 {
+			return failureClassTransient
+		}
+		if statusCode >= 400 {
+			return failureClassPermanent
+		}
+		return failureClassUnclassified
+	}
+}
+
+func shouldRetryRequest(ctx context.Context, method string, class failureClass, attempt int) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	return attempt < maxSafeReadRetries && isRetryableRead(method, class)
+}
+
+func isRetryableRead(method string, class failureClass) bool {
+	return strings.EqualFold(method, http.MethodGet) && class == failureClassTransient
+}
+
+func waitBeforeRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func retryDelay(err error) time.Duration {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		if delay := retryAfterDelay(apiErr.RetryAfter); delay > 0 {
+			return delay
+		}
+	}
+	return defaultRetryDelay
+}
+
+func retryAfterDelay(raw string) time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(raw); err == nil {
+		return capRetryDelay(time.Duration(seconds) * time.Second)
+	}
+	if retryAt, err := http.ParseTime(raw); err == nil {
+		return capRetryDelay(time.Until(retryAt))
+	}
+	return 0
+}
+
+func capRetryDelay(delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return 0
+	}
+	if delay > maxRetryDelay {
+		return maxRetryDelay
+	}
+	return delay
+}
+
+func decorateRequestError(method string, path string, err error, class failureClass, retryAttempted bool, retryable bool) error {
+	return &classifiedRequestError{
+		err:            err,
+		class:          class,
+		method:         method,
+		path:           path,
+		retryAttempted: retryAttempted,
+		retryable:      retryable,
+	}
 }
 
 func (c *Client) setAuth(req *http.Request) {
@@ -322,6 +512,7 @@ func newAPIError(resp *http.Response, method string, path string) error {
 		Path:       path,
 		Message:    message,
 		Body:       body,
+		RetryAfter: resp.Header.Get("Retry-After"),
 	}
 }
 

--- a/internal/pfsense/client_test.go
+++ b/internal/pfsense/client_test.go
@@ -518,6 +518,40 @@ func TestGetRetriesTransientTransportFailureOnce(t *testing.T) {
 	}
 }
 
+func TestGetRetriesClientTimeoutOnce(t *testing.T) {
+	t.Parallel()
+
+	var seen atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if seen.Add(1) == 1 {
+			time.Sleep(200 * time.Millisecond)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{
+		Endpoint: server.URL,
+		APIKey:   "test-key",
+		Timeout:  50 * time.Millisecond,
+	})
+	var response struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.Get(context.Background(), "/haproxy/test", &response); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if !response.OK {
+		t.Fatalf("response not decoded")
+	}
+	if got := seen.Load(); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
+	}
+}
+
 func TestPostTransientHTTPFailureIsNotRetried(t *testing.T) {
 	t.Parallel()
 
@@ -676,6 +710,52 @@ func TestRetryWaitHonorsContextCancellation(t *testing.T) {
 	}
 	if got := seen.Load(); got != 1 {
 		t.Fatalf("requests = %d, want 1", got)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error %q does not wrap context.Canceled", err.Error())
+	}
+	for _, want := range []string{"Classified as transient", "safe GET retry wait canceled"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
+func TestEnvelopeRetryWaitHonorsRetryAfterAndContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	var seen atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		seen.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "1")
+		_, _ = w.Write([]byte(`{
+			"code": 503,
+			"status": "error",
+			"response_id": "resp-retry-after",
+			"message": "retry later"
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	time.AfterFunc(150*time.Millisecond, cancel)
+
+	start := time.Now()
+	err := client.Get(ctx, "/haproxy/test", nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("retry wait did not honor context cancellation; elapsed = %s", elapsed)
+	}
+	if got := seen.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error %q does not wrap context.Canceled", err.Error())
 	}
 	for _, want := range []string{"Classified as transient", "safe GET retry wait canceled"} {
 		if !strings.Contains(err.Error(), want) {

--- a/internal/pfsense/client_test.go
+++ b/internal/pfsense/client_test.go
@@ -460,6 +460,230 @@ func TestAPIErrorResponsesAreActionable(t *testing.T) {
 	}
 }
 
+func TestGetRetriesTransientHTTPFailureOnce(t *testing.T) {
+	t.Parallel()
+
+	var seen atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if seen.Add(1) == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"message":"pfSense reload in progress"}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+	var response struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.Get(context.Background(), "/haproxy/test", &response); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if !response.OK {
+		t.Fatalf("response not decoded")
+	}
+	if got := seen.Load(); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
+	}
+}
+
+func TestGetRetriesTransientTransportFailureOnce(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Config{Endpoint: "https://pfsense.example.com", APIKey: "test-key"})
+	var seen atomic.Int32
+	client.httpClient.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if seen.Add(1) == 1 {
+			return nil, temporaryTimeoutError{}
+		}
+		return testJSONResponse(req, `{"ok":true}`), nil
+	})
+
+	var response struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.Get(context.Background(), "/haproxy/test", &response); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if !response.OK {
+		t.Fatalf("response not decoded")
+	}
+	if got := seen.Load(); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
+	}
+}
+
+func TestPostTransientHTTPFailureIsNotRetried(t *testing.T) {
+	t.Parallel()
+
+	var seen atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		seen.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"message":"temporary API outage"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+	err := client.Post(context.Background(), "/haproxy/test", map[string]string{"name": "backend-a"}, nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := seen.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
+	}
+	for _, want := range []string{"Classified as transient", "unsafe config write was not retried automatically", "Refresh or inspect live pfSense HAProxy state"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
+func TestPostTransientTransportFailureIsNotRetried(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(Config{Endpoint: "https://pfsense.example.com", APIKey: "test-key"})
+	var seen atomic.Int32
+	client.httpClient.Transport = roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		seen.Add(1)
+		return nil, temporaryTimeoutError{}
+	})
+
+	err := client.Post(context.Background(), "/haproxy/test", map[string]string{"name": "backend-a"}, nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := seen.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
+	}
+	for _, want := range []string{"Classified as transient", "unsafe config write was not retried automatically", "Refresh or inspect live pfSense HAProxy state"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
+func TestGetPermanentFailuresAreNotRetried(t *testing.T) {
+	t.Parallel()
+
+	statuses := []int{
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusConflict,
+		http.StatusUnprocessableEntity,
+	}
+
+	for _, status := range statuses {
+		status := status
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+
+			var seen atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				seen.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"message":"permanent failure"}`))
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+			err := client.Get(context.Background(), "/haproxy/test", nil)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if got := seen.Load(); got != 1 {
+				t.Fatalf("requests = %d, want 1", got)
+			}
+			if !strings.Contains(err.Error(), "Classified as permanent") {
+				t.Fatalf("error %q does not classify permanent failure", err.Error())
+			}
+		})
+	}
+}
+
+func TestGetRetriesTransientEnvelopeFailureOnce(t *testing.T) {
+	t.Parallel()
+
+	var seen atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if seen.Add(1) == 1 {
+			_, _ = w.Write([]byte(`{
+				"code": 503,
+				"status": "error",
+				"response_id": "resp-transient",
+				"message": "reload in progress"
+			}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"code": 200,
+			"status": "ok",
+			"data": {"ok": true}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+	var response struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.Get(context.Background(), "/haproxy/test", &response); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if !response.OK {
+		t.Fatalf("response not decoded")
+	}
+	if got := seen.Load(); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
+	}
+}
+
+func TestRetryWaitHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	var seen atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		seen.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"message":"retry later"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(Config{Endpoint: server.URL, APIKey: "test-key"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	start := time.Now()
+	err := client.Get(ctx, "/haproxy/test", nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("retry wait did not honor context cancellation; elapsed = %s", elapsed)
+	}
+	if got := seen.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
+	}
+	for _, want := range []string{"Classified as transient", "safe GET retry wait canceled"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+}
+
 func TestEnvelopeResponseDecodesData(t *testing.T) {
 	t.Parallel()
 
@@ -681,6 +905,20 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+type temporaryTimeoutError struct{}
+
+func (temporaryTimeoutError) Error() string {
+	return "temporary timeout"
+}
+
+func (temporaryTimeoutError) Timeout() bool {
+	return true
+}
+
+func (temporaryTimeoutError) Temporary() bool {
+	return true
 }
 
 func configWriteGuardHeld() bool {


### PR DESCRIPTION
## Summary

Closes #20.

- add REST client failure classification for transient vs permanent failures
- retry only safe `GET` requests once for transient HTTP/API-envelope/transport failures, honoring bounded `Retry-After`
- keep mutating `POST`/`PATCH`/`PUT`/`DELETE` requests non-replayed and add operator guidance for live pfSense state inspection
- document the read-retry/write-no-replay contract in `README.md`

## Validation

- `go test ./...`
- `make lint`
- `terraform fmt -check -recursive .`
- `git diff --check`

Fresh tester and adversarial review are running independently before merge.