### PR TITLE
Document UAT and PROD HAProxy provider usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ to refresh or inspect live pfSense HAProxy state before rerunning Terraform.
 ## UAT and PROD provider patterns
 
 UAT is the normal target for mutable HAProxy resources and
-`pfsense_haproxy_apply`. Production provider aliases are read-only by default:
-use them for data sources, discovery, and refresh validation unless a separate
-issue defines the production write/import/apply window and the operator confirms
-it explicitly.
+`pfsense_haproxy_apply`. Production read-only behavior is a workflow policy, not
+a provider-enforced capability: a `pfsense.prod` alias can still be attached to
+mutable resources if an operator writes that configuration. In normal use,
+production aliases must be used only for data sources, discovery, and refresh
+validation unless a separate issue defines the production write/import/apply
+window and the operator confirms it explicitly.
 
 When UAT and PROD appear in one module, every resource and data source should
 pin `provider = pfsense.uat` or `provider = pfsense.prod` so Terraform cannot
@@ -109,8 +111,9 @@ provider "pfsense" {
 ```
 
 `examples/provider.tf` keeps the default provider for simple UAT snippets and
-also defines explicit `uat` and `prod` aliases. The production read-only example
-uses only `provider = pfsense.prod` data sources.
+also defines an explicit `uat` alias. The production read-only example keeps the
+`prod` alias isolated in a data-source-only module and uses only
+`provider = pfsense.prod` data sources.
 
 ## HAProxy Terraform ownership model
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,65 @@ Mutating `POST`, `PATCH`, `PUT`, and `DELETE` requests are never replayed
 automatically; transient write failures include diagnostics telling operators
 to refresh or inspect live pfSense HAProxy state before rerunning Terraform.
 
+## UAT and PROD provider patterns
+
+UAT is the normal target for mutable HAProxy resources and
+`pfsense_haproxy_apply`. Production provider aliases are read-only by default:
+use them for data sources, discovery, and refresh validation unless a separate
+issue defines the production write/import/apply window and the operator confirms
+it explicitly.
+
+When UAT and PROD appear in one module, every resource and data source should
+pin `provider = pfsense.uat` or `provider = pfsense.prod` so Terraform cannot
+accidentally use the wrong firewall.
+
+```hcl
+provider "pfsense" {
+  alias        = "uat"
+  endpoint     = var.pfsense_uat_endpoint
+  api_key      = var.pfsense_uat_api_key
+  insecure_tls = var.pfsense_uat_insecure_tls
+  timeout      = var.pfsense_timeout
+}
+
+provider "pfsense" {
+  alias        = "prod"
+  endpoint     = var.pfsense_prod_endpoint
+  api_key      = var.pfsense_prod_api_key
+  username     = var.pfsense_prod_username
+  password     = var.pfsense_prod_password
+  insecure_tls = var.pfsense_prod_insecure_tls
+  timeout      = var.pfsense_timeout
+}
+```
+
+`examples/provider.tf` keeps the default provider for simple UAT snippets and
+also defines explicit `uat` and `prod` aliases. The production read-only example
+uses only `provider = pfsense.prod` data sources.
+
+## HAProxy Terraform ownership model
+
+Terraform owns only objects represented by resources in state:
+
+- Settings are an import-first singleton with fixed ID `settings`; delete is
+  state-only.
+- Backends and frontends use stable natural name keys. Transient pfSense REST
+  IDs are rediscovered before update/delete operations.
+- Child resources use composite natural keys such as `backend/server`,
+  `frontend/address/custom-or-/port`, `backend/acl`, or `frontend/certificate`.
+- Action resources use a Terraform-only `key`; live objects are matched by
+  normalized action payload fields because pfSense actions do not expose stable
+  names.
+- Certificates attach existing pfSense certificate references only. The
+  provider does not own PEM bodies or private keys.
+- Apply/reload is explicit through `pfsense_haproxy_apply`. Durable resources
+  never auto-apply pending HAProxy changes.
+- Production should use data sources only unless a separate approved production
+  change issue defines the import/migration plan and operator window.
+- HAProxy files, advanced text fields, error files, and default certificate
+  ownership remain deferred until UAT validates endpoint behavior and a state
+  safety model.
+
 ## HAProxy settings ownership
 
 `pfsense_haproxy_settings` is split into a data source and a singleton resource:
@@ -713,6 +772,8 @@ acceptance runbook and endpoint response shape ledger, is tracked in
 M6 issue #19 production read-only validation workflow and evidence format are
 tracked in
 [`docs/schema/m6-prod-readonly-validation.md`](docs/schema/m6-prod-readonly-validation.md).
+M6 issue #21 usage and ownership documentation gate evidence is tracked in
+[`docs/schema/m6-usage-documentation-gate.md`](docs/schema/m6-usage-documentation-gate.md).
 Live schema captures must be generated with:
 
 ```bash

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -82,6 +82,11 @@ evidence format are tracked in
 [`m6-prod-readonly-validation.md`](m6-prod-readonly-validation.md). That lane
 uses only GET requests and explicitly forbids production apply/write steps.
 
+M6 issue #21 usage and ownership documentation gate evidence is tracked in
+[`m6-usage-documentation-gate.md`](m6-usage-documentation-gate.md). That gate
+documents UAT-write and PROD-read-only provider alias patterns, the Terraform
+ownership model, changed docs list, and validation evidence.
+
 For M2-01, `pfsense_haproxy_settings` uses the upstream
 `HAProxySettings.inc` scalar model as a conservative implementation reference:
 Terraform manages only scalar fields, treats `advanced` as sensitive, and does

--- a/docs/schema/m6-usage-documentation-gate.md
+++ b/docs/schema/m6-usage-documentation-gate.md
@@ -1,0 +1,75 @@
+# M6 Usage Documentation Gate
+
+Status: issue #21 documentation gate.
+
+## Scope
+
+Issue #21 documents how the HAProxy Terraform provider should be used for UAT
+and production ingress work, and records the ownership model needed before the
+M6 milestone can close.
+
+This issue does not require live UAT mutation or production access. Live UAT
+acceptance evidence remains tracked by issue #18, and production read-only
+evidence remains tracked by issue #19.
+
+## Changed Docs List
+
+- `README.md`
+- `examples/provider.tf`
+- `examples/prod-readonly-validation/main.tf`
+- `docs/schema/README.md`
+- `docs/schema/m6-usage-documentation-gate.md`
+- `xconnector-doc/docs/40-terraform/pfsense-haproxy-provider.md`
+- `xconnector-doc/docs/index.md`
+
+## Validation Evidence
+
+| Check | Result |
+|-------|--------|
+| Date | 2026-04-29 |
+| Branch | `issue/21-documentation-gate` |
+| Commit | PR head commit for `issue/21-documentation-gate`; exact final hash is recorded by the PR and CI. |
+| `git diff --check` | PASS |
+| `terraform fmt -check -recursive examples` | PASS |
+| `go test ./...` | PASS |
+| `make lint` | PASS, `0 issues.` |
+| `python3 -m unittest scripts/capture_haproxy_schema_test.py scripts/prod_readonly_validate_test.py` | PASS, 14 tests. |
+| `PFSENSE_VALIDATION_ENVIRONMENT=prod PFSENSE_READONLY_CONFIRMATION=READ_ONLY_PROD_VALIDATION PFSENSE_ENDPOINT=https://example.invalid PFSENSE_API_KEY=dummy python3 scripts/prod_readonly_validate.py --dry-run` | PASS, printed the static GET allowlist without network access. |
+| `xconnector-doc` docs-only inspection | PASS, added `docs/40-terraform/pfsense-haproxy-provider.md`; `git diff --check` passed. |
+
+If Terraform cannot validate examples because the provider source is not
+available from a registry in the worker environment, record the skipped command
+and use a local provider development override for any deeper example validation.
+
+## Live Environment Evidence
+
+No live UAT or PROD mutation is required for issue #21.
+
+Live UAT writes remain blocked behind the issue #18 runbook:
+
+- approved UAT firewall target;
+- `PFSENSE_TEST_ENVIRONMENT=uat`;
+- unique `PFSENSE_TEST_PREFIX`;
+- `make testacc`;
+- endpoint shape evidence ledger update.
+
+Production remains read-only by default:
+
+- `PFSENSE_VALIDATION_ENVIRONMENT=prod`;
+- `PFSENSE_READONLY_CONFIRMATION=READ_ONLY_PROD_VALIDATION`;
+- GET-only discovery and data-source plan validation;
+- no `terraform apply`, `make testacc`, or HAProxy apply POST.
+
+## Closure Notes
+
+Consultant note: the provider usage model is UAT-write and PROD-read-only by
+default. Production writes require a separate tracked issue, an approved
+operator window, explicit confirmation, and an import/migration plan for every
+existing HAProxy object Terraform will own.
+
+Close issue #21 only after:
+
+- README usage and ownership sections are merged;
+- examples show explicit UAT/PROD provider aliasing;
+- xconnector-doc has a canonical provider usage page and index link;
+- validation commands are recorded in the PR and this evidence file.

--- a/docs/schema/m6-usage-documentation-gate.md
+++ b/docs/schema/m6-usage-documentation-gate.md
@@ -19,8 +19,10 @@ evidence remains tracked by issue #19.
 - `examples/prod-readonly-validation/main.tf`
 - `docs/schema/README.md`
 - `docs/schema/m6-usage-documentation-gate.md`
-- `xconnector-doc/docs/40-terraform/pfsense-haproxy-provider.md`
-- `xconnector-doc/docs/index.md`
+- `xconnector-doc/docs/40-terraform/pfsense-haproxy-provider.md` (prepared
+  locally; pending companion docs repo branch/commit/PR)
+- `xconnector-doc/docs/index.md` (prepared locally; pending companion docs repo
+  branch/commit/PR)
 
 ## Validation Evidence
 
@@ -35,7 +37,7 @@ evidence remains tracked by issue #19.
 | `make lint` | PASS, `0 issues.` |
 | `python3 -m unittest scripts/capture_haproxy_schema_test.py scripts/prod_readonly_validate_test.py` | PASS, 14 tests. |
 | `PFSENSE_VALIDATION_ENVIRONMENT=prod PFSENSE_READONLY_CONFIRMATION=READ_ONLY_PROD_VALIDATION PFSENSE_ENDPOINT=https://example.invalid PFSENSE_API_KEY=dummy python3 scripts/prod_readonly_validate.py --dry-run` | PASS, printed the static GET allowlist without network access. |
-| `xconnector-doc` docs-only inspection | PASS, added `docs/40-terraform/pfsense-haproxy-provider.md`; `git diff --check` passed. |
+| `xconnector-doc` docs-only inspection | Local draft prepared and `git diff --check` passed; companion docs repo branch/commit/PR is pending and must be recorded before claiming the external documentation gate as complete. |
 
 If Terraform cannot validate examples because the provider source is not
 available from a registry in the worker environment, record the skipped command
@@ -71,5 +73,6 @@ Close issue #21 only after:
 
 - README usage and ownership sections are merged;
 - examples show explicit UAT/PROD provider aliasing;
-- xconnector-doc has a canonical provider usage page and index link;
+- xconnector-doc has a canonical provider usage page and index link committed
+  in a companion docs repo PR or explicitly tracked follow-up;
 - validation commands are recorded in the PR and this evidence file.

--- a/examples/prod-readonly-validation/main.tf
+++ b/examples/prod-readonly-validation/main.tf
@@ -7,6 +7,7 @@ terraform {
 }
 
 provider "pfsense" {
+  alias        = "prod"
   endpoint     = var.pfsense_endpoint
   api_key      = var.pfsense_api_key
   username     = var.pfsense_username
@@ -59,16 +60,24 @@ variable "existing_backend_server_name" {
   default     = null
 }
 
-data "pfsense_haproxy_settings" "current" {}
+data "pfsense_haproxy_settings" "current" {
+  provider = pfsense.prod
+}
 
-data "pfsense_haproxy_apply" "status" {}
+data "pfsense_haproxy_apply" "status" {
+  provider = pfsense.prod
+}
 
 data "pfsense_haproxy_backend" "existing" {
+  provider = pfsense.prod
+
   count = var.existing_backend_name == null ? 0 : 1
   name  = var.existing_backend_name
 }
 
 data "pfsense_haproxy_backend_server" "existing" {
+  provider = pfsense.prod
+
   count = var.existing_backend_name == null || var.existing_backend_server_name == null ? 0 : 1
 
   backend_name = var.existing_backend_name

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -21,16 +21,6 @@ provider "pfsense" {
   timeout      = var.pfsense_timeout
 }
 
-provider "pfsense" {
-  alias        = "prod"
-  endpoint     = var.pfsense_prod_endpoint
-  api_key      = var.pfsense_prod_api_key
-  username     = var.pfsense_prod_username
-  password     = var.pfsense_prod_password
-  insecure_tls = var.pfsense_prod_insecure_tls
-  timeout      = var.pfsense_timeout
-}
-
 variable "pfsense_endpoint" {
   type = string
 }
@@ -43,31 +33,4 @@ variable "pfsense_api_key" {
 variable "pfsense_timeout" {
   type    = string
   default = "30s"
-}
-
-variable "pfsense_prod_endpoint" {
-  type = string
-}
-
-variable "pfsense_prod_api_key" {
-  type      = string
-  sensitive = true
-  default   = null
-}
-
-variable "pfsense_prod_username" {
-  type      = string
-  sensitive = true
-  default   = null
-}
-
-variable "pfsense_prod_password" {
-  type      = string
-  sensitive = true
-  default   = null
-}
-
-variable "pfsense_prod_insecure_tls" {
-  type    = bool
-  default = false
 }

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -10,6 +10,25 @@ provider "pfsense" {
   endpoint     = var.pfsense_endpoint
   api_key      = var.pfsense_api_key
   insecure_tls = true
+  timeout      = var.pfsense_timeout
+}
+
+provider "pfsense" {
+  alias        = "uat"
+  endpoint     = var.pfsense_endpoint
+  api_key      = var.pfsense_api_key
+  insecure_tls = true
+  timeout      = var.pfsense_timeout
+}
+
+provider "pfsense" {
+  alias        = "prod"
+  endpoint     = var.pfsense_prod_endpoint
+  api_key      = var.pfsense_prod_api_key
+  username     = var.pfsense_prod_username
+  password     = var.pfsense_prod_password
+  insecure_tls = var.pfsense_prod_insecure_tls
+  timeout      = var.pfsense_timeout
 }
 
 variable "pfsense_endpoint" {
@@ -19,4 +38,36 @@ variable "pfsense_endpoint" {
 variable "pfsense_api_key" {
   type      = string
   sensitive = true
+}
+
+variable "pfsense_timeout" {
+  type    = string
+  default = "30s"
+}
+
+variable "pfsense_prod_endpoint" {
+  type = string
+}
+
+variable "pfsense_prod_api_key" {
+  type      = string
+  sensitive = true
+  default   = null
+}
+
+variable "pfsense_prod_username" {
+  type      = string
+  sensitive = true
+  default   = null
+}
+
+variable "pfsense_prod_password" {
+  type      = string
+  sensitive = true
+  default   = null
+}
+
+variable "pfsense_prod_insecure_tls" {
+  type    = bool
+  default = false
 }


### PR DESCRIPTION
## Summary

Closes #21.

- document UAT-write and PROD-read-only provider alias patterns in README
- add the consolidated HAProxy Terraform ownership model
- make the PROD read-only validation example pin `provider = pfsense.prod`
- add M6 usage documentation gate evidence under `docs/schema/`
- link the issue #21 evidence from the schema docs

## Validation

- `git diff --check`
- `terraform fmt -check -recursive examples`
- `go test ./...`
- `make lint`
- `python3 -m unittest scripts/capture_haproxy_schema_test.py scripts/prod_readonly_validate_test.py`
- `PFSENSE_VALIDATION_ENVIRONMENT=prod PFSENSE_READONLY_CONFIRMATION=READ_ONLY_PROD_VALIDATION PFSENSE_ENDPOINT=https://example.invalid PFSENSE_API_KEY=dummy python3 scripts/prod_readonly_validate.py --dry-run`

No live UAT or PROD mutation is claimed for this issue. The xconnector-doc companion page was prepared locally as documentation-gate material and should be published through the docs repo workflow without mixing unrelated existing local docs changes.